### PR TITLE
feat(transcript): implement transcript retrieval and display feature

### DIFF
--- a/src/app/(dashboard)/meetings/[id]/_components/index.ts
+++ b/src/app/(dashboard)/meetings/[id]/_components/index.ts
@@ -16,3 +16,6 @@ export { MeetingActions } from './meeting-actions';
 export type { MeetingActionsProps } from './meeting-actions';
 
 export { MeetingDetailSkeleton } from './meeting-detail-skeleton';
+
+export { TranscriptSection } from './transcript-section';
+export type { TranscriptSectionProps } from './transcript-section';

--- a/src/app/(dashboard)/meetings/[id]/_components/transcript-section.tsx
+++ b/src/app/(dashboard)/meetings/[id]/_components/transcript-section.tsx
@@ -1,0 +1,226 @@
+/**
+ * Transcript Section Component
+ * Fetches and displays meeting transcript with loading/error states
+ * @module app/(dashboard)/meetings/[id]/_components/transcript-section
+ */
+
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { TranscriptViewer } from '@/components/transcript';
+import type { Transcript, TranscriptSegment } from '@/types/transcript';
+
+/**
+ * API response type for transcript
+ */
+interface TranscriptApiResponse {
+  readonly data: Transcript;
+}
+
+/**
+ * API error response type
+ */
+interface ApiErrorResponse {
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+  };
+}
+
+/**
+ * Props for TranscriptSection component
+ */
+export interface TranscriptSectionProps {
+  /** Meeting ID to fetch transcript for */
+  readonly meetingId: string;
+  /** Meeting title for display */
+  readonly meetingTitle?: string | undefined;
+  /** Callback when a segment is clicked */
+  readonly onSegmentClick?: (segment: TranscriptSegment) => void;
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Component state interface
+ */
+interface ComponentState {
+  readonly transcript: Transcript | null;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+}
+
+/**
+ * Initial component state
+ */
+const initialState: ComponentState = {
+  transcript: null,
+  isLoading: true,
+  error: null,
+};
+
+/**
+ * Error display component
+ */
+function TranscriptError({
+  message,
+  onRetry,
+}: {
+  readonly message: string;
+  readonly onRetry: () => void;
+}): JSX.Element {
+  return (
+    <div className="bg-white rounded-lg border border-lark-border p-8">
+      <div className="text-center">
+        <svg
+          className="mx-auto h-12 w-12 text-red-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+        <h3 className="mt-4 text-lg font-medium text-slate-900 dark:text-white">
+          Failed to load transcript
+        </h3>
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          {message}
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-4 inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
+        >
+          <svg
+            className="w-4 h-4 mr-2"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+          Retry
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * TranscriptSection Component
+ *
+ * @description Fetches and displays meeting transcript with proper loading,
+ *              error, and empty states. Uses TranscriptViewer for display.
+ *
+ * @example
+ * ```tsx
+ * <TranscriptSection
+ *   meetingId="meeting-123"
+ *   meetingTitle="Weekly Standup"
+ *   onSegmentClick={handleSegmentClick}
+ * />
+ * ```
+ */
+export function TranscriptSection({
+  meetingId,
+  meetingTitle,
+  onSegmentClick,
+  className = '',
+}: TranscriptSectionProps): JSX.Element {
+  const [state, setState] = useState<ComponentState>(initialState);
+
+  /**
+   * Fetch transcript data from API
+   */
+  const fetchTranscript = useCallback(async (): Promise<void> => {
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      const response = await fetch(`/api/meetings/${meetingId}/transcript`);
+
+      if (response.status === 404) {
+        // Transcript not found is not an error - meeting may not have transcript
+        setState({
+          transcript: null,
+          isLoading: false,
+          error: null,
+        });
+        return;
+      }
+
+      if (!response.ok) {
+        const errorData = (await response.json()) as ApiErrorResponse;
+        throw new Error(errorData.error.message ?? 'Failed to fetch transcript');
+      }
+
+      const data = (await response.json()) as TranscriptApiResponse;
+      setState({
+        transcript: data.data,
+        isLoading: false,
+        error: null,
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'An unexpected error occurred';
+      setState({
+        transcript: null,
+        isLoading: false,
+        error: message,
+      });
+    }
+  }, [meetingId]);
+
+  /**
+   * Handle retry action
+   */
+  const handleRetry = useCallback((): void => {
+    void fetchTranscript();
+  }, [fetchTranscript]);
+
+  // Fetch transcript on mount and when meetingId changes
+  useEffect(() => {
+    void fetchTranscript();
+  }, [fetchTranscript]);
+
+  // Show error state
+  if (state.error !== null) {
+    return (
+      <section className={className} aria-label="Transcript section">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+          Transcript
+        </h2>
+        <TranscriptError message={state.error} onRetry={handleRetry} />
+      </section>
+    );
+  }
+
+  // Build props conditionally for exactOptionalPropertyTypes compliance
+  const viewerProps = {
+    transcript: state.transcript ?? undefined,
+    isLoading: state.isLoading,
+    meetingTitle,
+    virtualScrollThreshold: 50,
+    ...(onSegmentClick !== undefined && { onSegmentClick }),
+  };
+
+  return (
+    <section className={className} aria-label="Transcript section">
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+        Transcript
+      </h2>
+      <TranscriptViewer {...viewerProps} />
+    </section>
+  );
+}

--- a/src/app/(dashboard)/meetings/[id]/page.tsx
+++ b/src/app/(dashboard)/meetings/[id]/page.tsx
@@ -22,6 +22,7 @@ import {
   RecordingsList,
   MeetingActions,
   MeetingDetailSkeleton,
+  TranscriptSection,
 } from './_components';
 import type { ParticipantData } from './_components/participants-list';
 import type { RecordingData } from './_components/recordings-list';
@@ -408,6 +409,12 @@ export default function MeetingDetailPage(): JSX.Element {
               recordings={recordings}
               isLoading={state.recordingsLoading}
               error={state.recordingsError}
+            />
+
+            {/* Transcript Section */}
+            <TranscriptSection
+              meetingId={meeting.id}
+              meetingTitle={meeting.title}
             />
           </div>
 

--- a/src/app/api/meetings/[id]/transcript/route.ts
+++ b/src/app/api/meetings/[id]/transcript/route.ts
@@ -1,0 +1,191 @@
+/**
+ * Transcript API endpoint - Get transcript for a meeting
+ * @module app/api/meetings/[id]/transcript/route
+ */
+
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth/get-session';
+import {
+  createTranscriptService,
+  TranscriptNotFoundError,
+  TranscriptServiceError,
+} from '@/services/transcript.service';
+import type { Transcript } from '@/types/transcript';
+
+/**
+ * Error response type
+ */
+interface ErrorResponse {
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+    readonly details?: unknown;
+  };
+}
+
+/**
+ * Success response type for transcript
+ */
+interface TranscriptResponse {
+  readonly data: Transcript;
+}
+
+/**
+ * Route context with params
+ */
+interface RouteContext {
+  readonly params: Promise<{
+    readonly id: string;
+  }>;
+}
+
+/**
+ * Create error response
+ *
+ * @param code - Error code
+ * @param message - Error message
+ * @param statusCode - HTTP status code
+ * @param details - Optional error details
+ * @returns NextResponse with error payload
+ */
+function createErrorResponse(
+  code: string,
+  message: string,
+  statusCode: number,
+  details?: unknown
+): NextResponse<ErrorResponse> {
+  const response: ErrorResponse = {
+    error: {
+      code,
+      message,
+      ...(details !== undefined && { details }),
+    },
+  };
+
+  return NextResponse.json(response, { status: statusCode });
+}
+
+/**
+ * GET /api/meetings/[id]/transcript
+ *
+ * Get transcript data for a specific meeting.
+ *
+ * Path Parameters:
+ * - id: string - Meeting ID
+ *
+ * Response:
+ * - 200: Transcript data
+ * - 401: Unauthorized (not authenticated)
+ * - 404: Transcript not found
+ * - 500: Internal Server Error
+ *
+ * @example
+ * ```typescript
+ * // Success response
+ * {
+ *   "data": {
+ *     "meetingId": "meeting-123",
+ *     "language": "ja",
+ *     "segments": [
+ *       {
+ *         "id": "seg-1",
+ *         "startTime": 0,
+ *         "endTime": 15200,
+ *         "speaker": { "id": "user-1", "name": "Tanaka Taro" },
+ *         "text": "Let's start the weekly meeting.",
+ *         "confidence": 0.95
+ *       }
+ *     ],
+ *     "totalDuration": 3600000,
+ *     "createdAt": "2026-01-22T10:00:00.000Z"
+ *   }
+ * }
+ * ```
+ */
+export async function GET(
+  _request: Request,
+  context: RouteContext
+): Promise<Response> {
+  try {
+    // 1. Authentication check
+    const session = await getSession();
+
+    if (session === null || !session.isAuthenticated) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Authentication required',
+        401
+      );
+    }
+
+    if (session.accessToken === undefined) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Access token not found',
+        401
+      );
+    }
+
+    // 2. Get meeting ID from path params
+    const params = await context.params;
+    const meetingId = params.id;
+
+    if (meetingId === undefined || meetingId.trim() === '') {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'Meeting ID is required',
+        400
+      );
+    }
+
+    // 3. Create service and fetch transcript
+    const transcriptService = createTranscriptService();
+
+    const transcript = await transcriptService.getTranscript(
+      session.accessToken,
+      meetingId
+    );
+
+    // 4. Return success response
+    const response: TranscriptResponse = {
+      data: transcript,
+    };
+
+    return NextResponse.json(response);
+  } catch (error) {
+    console.error('[GET /api/meetings/[id]/transcript] Error:', error);
+
+    // 5. Error handling
+
+    // Handle transcript not found
+    if (error instanceof TranscriptNotFoundError) {
+      return createErrorResponse(
+        'NOT_FOUND',
+        `Transcript not found for meeting: ${error.meetingId}`,
+        404
+      );
+    }
+
+    // Handle transcript service errors
+    if (error instanceof TranscriptServiceError) {
+      const statusCode =
+        error.statusCode >= 400 && error.statusCode < 600
+          ? error.statusCode
+          : 500;
+
+      return createErrorResponse(
+        error.code,
+        error.message,
+        statusCode,
+        error.details
+      );
+    }
+
+    // Handle unknown errors
+    return createErrorResponse(
+      'INTERNAL_ERROR',
+      'An unexpected error occurred',
+      500
+    );
+  }
+}

--- a/src/components/transcript/SpeakerSegment.tsx
+++ b/src/components/transcript/SpeakerSegment.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { memo, useMemo } from 'react';
+import { Avatar } from '@/components/ui';
+import type { TranscriptSegment, TranscriptSearchMatch } from '@/types/transcript';
+import { formatTimestamp } from '@/types/transcript';
+
+/**
+ * Props for SpeakerSegment component
+ */
+export interface SpeakerSegmentProps {
+  /** Transcript segment data */
+  readonly segment: TranscriptSegment;
+  /** Search matches within this segment for highlighting */
+  readonly searchMatches?: readonly TranscriptSearchMatch[] | undefined;
+  /** Currently focused match index for this segment */
+  readonly focusedMatchIndex?: number | undefined;
+  /** Callback when segment is clicked */
+  readonly onSegmentClick?: ((segment: TranscriptSegment) => void) | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Render text with search highlights
+ */
+function renderHighlightedText(
+  text: string,
+  matches: readonly TranscriptSearchMatch[],
+  focusedMatchIndex: number | undefined
+): JSX.Element {
+  if (matches.length === 0) {
+    return <>{text}</>;
+  }
+
+  // Sort matches by start index
+  const sortedMatches = [...matches].sort((a, b) => a.startIndex - b.startIndex);
+
+  const parts: JSX.Element[] = [];
+  let lastIndex = 0;
+
+  sortedMatches.forEach((match, index) => {
+    // Add text before the match
+    if (match.startIndex > lastIndex) {
+      parts.push(
+        <span key={`text-${lastIndex}`}>
+          {text.slice(lastIndex, match.startIndex)}
+        </span>
+      );
+    }
+
+    // Add highlighted match
+    const isFocused = focusedMatchIndex === index;
+    parts.push(
+      <mark
+        key={`match-${match.startIndex}`}
+        className={`
+          rounded px-0.5
+          ${isFocused ? 'bg-yellow-400 ring-2 ring-yellow-500' : 'bg-yellow-200'}
+        `}
+        data-match-index={index}
+      >
+        {text.slice(match.startIndex, match.endIndex)}
+      </mark>
+    );
+
+    lastIndex = match.endIndex;
+  });
+
+  // Add remaining text after the last match
+  if (lastIndex < text.length) {
+    parts.push(<span key={`text-${lastIndex}`}>{text.slice(lastIndex)}</span>);
+  }
+
+  return <>{parts}</>;
+}
+
+/**
+ * SpeakerSegment component
+ *
+ * @description Displays a single speaker's utterance with timestamp and avatar
+ * @example
+ * ```tsx
+ * <SpeakerSegment
+ *   segment={{
+ *     id: '1',
+ *     speaker: { id: 'user-1', name: '田中太郎' },
+ *     startTime: 0,
+ *     endTime: 15000,
+ *     text: 'それでは週次定例を始めます。',
+ *     confidence: 0.95,
+ *   }}
+ * />
+ * ```
+ */
+function SpeakerSegmentInner({
+  segment,
+  searchMatches = [],
+  focusedMatchIndex,
+  onSegmentClick,
+  className = '',
+}: SpeakerSegmentProps): JSX.Element {
+  const formattedTime = useMemo(
+    () => formatTimestamp(segment.startTime),
+    [segment.startTime]
+  );
+
+  const handleClick = (): void => {
+    onSegmentClick?.(segment);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent): void => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSegmentClick?.(segment);
+    }
+  };
+
+  const isClickable = onSegmentClick !== undefined;
+
+  return (
+    <article
+      id={`segment-${segment.id}`}
+      className={`
+        flex gap-3 p-3 rounded-lg
+        transition-colors duration-150
+        ${isClickable ? 'cursor-pointer hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-lark-primary focus:ring-offset-2' : ''}
+        ${className}
+      `}
+      onClick={isClickable ? handleClick : undefined}
+      onKeyDown={isClickable ? handleKeyDown : undefined}
+      tabIndex={isClickable ? 0 : undefined}
+      role={isClickable ? 'button' : 'article'}
+      aria-label={`${segment.speaker.name}の発言 ${formattedTime}`}
+    >
+      {/* Timestamp */}
+      <div className="flex-shrink-0 w-12">
+        <time
+          dateTime={`PT${Math.floor(segment.startTime / 1000)}S`}
+          className="text-xs text-gray-500 font-mono"
+          aria-label={`開始時刻 ${formattedTime}`}
+        >
+          {formattedTime}
+        </time>
+      </div>
+
+      {/* Avatar */}
+      <div className="flex-shrink-0">
+        <Avatar
+          src={segment.speaker.avatarUrl}
+          name={segment.speaker.name}
+          size="sm"
+        />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        {/* Speaker name */}
+        <div className="text-sm font-medium text-lark-text mb-1">
+          {segment.speaker.name}
+        </div>
+
+        {/* Transcribed text */}
+        <div className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap break-words">
+          {renderHighlightedText(segment.text, searchMatches, focusedMatchIndex)}
+        </div>
+
+        {/* Confidence indicator (optional) */}
+        {segment.confidence < 0.7 && (
+          <div
+            className="mt-1 text-xs text-gray-400"
+            title={`認識精度: ${Math.round(segment.confidence * 100)}%`}
+          >
+            <span className="sr-only">低認識精度</span>
+            <svg
+              className="inline-block w-3 h-3 mr-1"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+            認識精度が低い可能性があります
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+export const SpeakerSegment = memo(SpeakerSegmentInner);

--- a/src/components/transcript/TranscriptSearch.tsx
+++ b/src/components/transcript/TranscriptSearch.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { memo, useCallback } from 'react';
+import type { TranscriptSearchResult } from '@/types/transcript';
+
+/**
+ * Props for TranscriptSearch component
+ */
+export interface TranscriptSearchProps {
+  /** Search result data */
+  readonly searchResult: TranscriptSearchResult;
+  /** Callback when navigating to previous match */
+  readonly onPrevious: () => void;
+  /** Callback when navigating to next match */
+  readonly onNext: () => void;
+  /** Whether navigation is disabled */
+  readonly disabled?: boolean | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * TranscriptSearch component
+ *
+ * @description Navigation controls for search results with match count display
+ * @example
+ * ```tsx
+ * <TranscriptSearch
+ *   searchResult={{
+ *     query: '進捗',
+ *     totalMatches: 5,
+ *     matches: [...],
+ *     currentMatchIndex: 2,
+ *   }}
+ *   onPrevious={handlePrevious}
+ *   onNext={handleNext}
+ * />
+ * ```
+ */
+function TranscriptSearchInner({
+  searchResult,
+  onPrevious,
+  onNext,
+  disabled = false,
+  className = '',
+}: TranscriptSearchProps): JSX.Element | null {
+  const { totalMatches, currentMatchIndex, query } = searchResult;
+
+  const handlePrevious = useCallback(() => {
+    if (!disabled && totalMatches > 0) {
+      onPrevious();
+    }
+  }, [disabled, totalMatches, onPrevious]);
+
+  const handleNext = useCallback(() => {
+    if (!disabled && totalMatches > 0) {
+      onNext();
+    }
+  }, [disabled, totalMatches, onNext]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'ArrowUp' || (event.key === 'Enter' && event.shiftKey)) {
+        event.preventDefault();
+        handlePrevious();
+      } else if (event.key === 'ArrowDown' || (event.key === 'Enter' && !event.shiftKey)) {
+        event.preventDefault();
+        handleNext();
+      }
+    },
+    [handlePrevious, handleNext]
+  );
+
+  // Don't render if no query
+  if (!query || query.length === 0) {
+    return null;
+  }
+
+  const isNavigationDisabled = disabled || totalMatches === 0;
+  const currentDisplay = totalMatches > 0 ? currentMatchIndex + 1 : 0;
+
+  return (
+    <div
+      className={`
+        flex items-center gap-2 px-3 py-2
+        bg-gray-50 border border-lark-border rounded-lg
+        ${className}
+      `}
+      role="navigation"
+      aria-label="検索結果ナビゲーション"
+      onKeyDown={handleKeyDown}
+    >
+      {/* Match count display */}
+      <div className="flex-1 text-sm text-gray-600" aria-live="polite">
+        {totalMatches > 0 ? (
+          <span>
+            <span className="font-medium">{currentDisplay}</span>
+            <span className="mx-1">/</span>
+            <span>{totalMatches}</span>
+            <span className="ml-1">件</span>
+          </span>
+        ) : (
+          <span className="text-gray-400">一致なし</span>
+        )}
+      </div>
+
+      {/* Navigation buttons */}
+      <div className="flex items-center gap-1">
+        {/* Previous button */}
+        <button
+          type="button"
+          onClick={handlePrevious}
+          disabled={isNavigationDisabled}
+          className={`
+            p-1.5 rounded
+            transition-colors duration-150
+            ${
+              isNavigationDisabled
+                ? 'text-gray-300 cursor-not-allowed'
+                : 'text-gray-600 hover:text-lark-primary hover:bg-gray-100'
+            }
+          `}
+          aria-label="前の検索結果"
+          title="前へ (Shift+Enter)"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M5 15l7-7 7 7"
+            />
+          </svg>
+        </button>
+
+        {/* Next button */}
+        <button
+          type="button"
+          onClick={handleNext}
+          disabled={isNavigationDisabled}
+          className={`
+            p-1.5 rounded
+            transition-colors duration-150
+            ${
+              isNavigationDisabled
+                ? 'text-gray-300 cursor-not-allowed'
+                : 'text-gray-600 hover:text-lark-primary hover:bg-gray-100'
+            }
+          `}
+          aria-label="次の検索結果"
+          title="次へ (Enter)"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 9l-7 7-7-7"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export const TranscriptSearch = memo(TranscriptSearchInner);

--- a/src/components/transcript/TranscriptSkeleton.tsx
+++ b/src/components/transcript/TranscriptSkeleton.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { memo } from 'react';
+import { Skeleton } from '@/components/ui';
+
+/**
+ * Props for TranscriptSegmentSkeleton component
+ */
+export interface TranscriptSegmentSkeletonProps {
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Single segment skeleton
+ */
+function TranscriptSegmentSkeletonInner({
+  className = '',
+}: TranscriptSegmentSkeletonProps): JSX.Element {
+  return (
+    <div className={`flex gap-3 p-3 ${className}`} aria-hidden="true">
+      {/* Timestamp skeleton */}
+      <div className="flex-shrink-0 w-12">
+        <Skeleton className="h-4 w-10" />
+      </div>
+
+      {/* Avatar skeleton */}
+      <div className="flex-shrink-0">
+        <Skeleton className="h-8 w-8 rounded-full" />
+      </div>
+
+      {/* Content skeleton */}
+      <div className="flex-1 min-w-0 space-y-2">
+        {/* Speaker name skeleton */}
+        <Skeleton className="h-4 w-24" />
+
+        {/* Text content skeleton (varying widths for realistic appearance) */}
+        <div className="space-y-1.5">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const TranscriptSegmentSkeleton = memo(TranscriptSegmentSkeletonInner);
+
+/**
+ * Props for TranscriptSkeleton component
+ */
+export interface TranscriptSkeletonProps {
+  /** Number of skeleton segments to display */
+  readonly segmentCount?: number | undefined;
+  /** Whether to show the header skeleton */
+  readonly showHeader?: boolean | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * TranscriptSkeleton component
+ *
+ * @description Loading skeleton for the transcript viewer
+ * @example
+ * ```tsx
+ * <TranscriptSkeleton segmentCount={5} showHeader />
+ * ```
+ */
+function TranscriptSkeletonInner({
+  segmentCount = 5,
+  showHeader = true,
+  className = '',
+}: TranscriptSkeletonProps): JSX.Element {
+  return (
+    <div
+      className={`bg-white rounded-lg border border-lark-border ${className}`}
+      role="status"
+      aria-label="文字起こしを読み込み中"
+    >
+      {/* Header skeleton */}
+      {showHeader && (
+        <div className="p-4 border-b border-lark-border">
+          <div className="flex items-center justify-between gap-4">
+            {/* Title skeleton */}
+            <div className="flex items-center gap-2 flex-1">
+              <Skeleton className="h-5 w-5" />
+              <Skeleton className="h-6 w-48" />
+            </div>
+
+            {/* Search input skeleton */}
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-9 w-48 rounded-lg" />
+              <Skeleton className="h-9 w-20 rounded-lg" />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Segments skeleton */}
+      <div className="divide-y divide-gray-100">
+        {Array.from({ length: segmentCount }, (_, index) => (
+          <TranscriptSegmentSkeleton key={index} />
+        ))}
+      </div>
+
+      {/* Visually hidden loading text for screen readers */}
+      <span className="sr-only">文字起こしを読み込み中...</span>
+    </div>
+  );
+}
+
+export const TranscriptSkeleton = memo(TranscriptSkeletonInner);

--- a/src/components/transcript/TranscriptViewer.tsx
+++ b/src/components/transcript/TranscriptViewer.tsx
@@ -1,0 +1,468 @@
+'use client';
+
+import {
+  useState,
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+  memo,
+} from 'react';
+import { SearchInput } from '@/components/ui';
+import type {
+  Transcript,
+  TranscriptSegment,
+  TranscriptSearchMatch,
+  TranscriptSearchResult,
+} from '@/types/transcript';
+import { filterSegments, createEmptySearchResult } from '@/types/transcript';
+import { SpeakerSegment } from './SpeakerSegment';
+import { TranscriptSearch } from './TranscriptSearch';
+import { TranscriptSkeleton } from './TranscriptSkeleton';
+
+/**
+ * Props for TranscriptViewer component
+ */
+export interface TranscriptViewerProps {
+  /** Transcript data to display */
+  readonly transcript?: Transcript | undefined;
+  /** Loading state */
+  readonly isLoading?: boolean | undefined;
+  /** Meeting title for header */
+  readonly meetingTitle?: string | undefined;
+  /** Callback when a segment is clicked */
+  readonly onSegmentClick?: (segment: TranscriptSegment) => void;
+  /** Initial search query */
+  readonly initialSearchQuery?: string | undefined;
+  /** Number of visible items for virtual scrolling (set 0 for all) */
+  readonly virtualScrollThreshold?: number | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Find all search matches in segments
+ */
+function findSearchMatches(
+  segments: readonly TranscriptSegment[],
+  query: string
+): TranscriptSearchResult {
+  if (!query || query.trim() === '') {
+    return createEmptySearchResult();
+  }
+
+  const trimmedQuery = query.trim().toLowerCase();
+  const matches: TranscriptSearchMatch[] = [];
+
+  segments.forEach((segment) => {
+    const lowerText = segment.text.toLowerCase();
+    let startIndex = 0;
+
+    while (true) {
+      const index = lowerText.indexOf(trimmedQuery, startIndex);
+      if (index === -1) break;
+
+      matches.push({
+        segmentId: segment.id,
+        startIndex: index,
+        endIndex: index + trimmedQuery.length,
+      });
+
+      startIndex = index + 1;
+    }
+  });
+
+  return {
+    query,
+    totalMatches: matches.length,
+    matches,
+    currentMatchIndex: matches.length > 0 ? 0 : -1,
+  };
+}
+
+/**
+ * Get matches for a specific segment
+ */
+function getSegmentMatches(
+  segmentId: string,
+  searchResult: TranscriptSearchResult
+): readonly TranscriptSearchMatch[] {
+  return searchResult.matches.filter((m) => m.segmentId === segmentId);
+}
+
+/**
+ * TranscriptViewer component
+ *
+ * @description Main component for displaying meeting transcripts with search,
+ *              filtering, and virtual scroll support
+ * @example
+ * ```tsx
+ * <TranscriptViewer
+ *   transcript={transcriptData}
+ *   isLoading={false}
+ *   meetingTitle="週次定例会議"
+ *   onSegmentClick={handleSegmentClick}
+ * />
+ * ```
+ */
+function TranscriptViewerInner({
+  transcript,
+  isLoading = false,
+  meetingTitle,
+  onSegmentClick,
+  initialSearchQuery = '',
+  virtualScrollThreshold = 100,
+  className = '',
+}: TranscriptViewerProps): JSX.Element {
+  // State
+  const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [visibleCount, setVisibleCount] = useState(virtualScrollThreshold);
+
+  // Refs
+  const containerRef = useRef<HTMLDivElement>(null);
+  const segmentRefs = useRef<Map<string, HTMLElement>>(new Map());
+
+  // Filter segments based on search
+  const filteredSegments = useMemo(() => {
+    if (!transcript) return [];
+
+    return filterSegments(transcript.segments, {
+      searchQuery: searchQuery || undefined,
+    });
+  }, [transcript, searchQuery]);
+
+  // Search results for highlighting
+  const searchResult = useMemo(() => {
+    if (!transcript) return createEmptySearchResult();
+    return findSearchMatches(transcript.segments, searchQuery);
+  }, [transcript, searchQuery]);
+
+  // Track current match state
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(
+    searchResult.currentMatchIndex
+  );
+
+  // Update current match when search changes
+  useEffect(() => {
+    setCurrentMatchIndex(searchResult.totalMatches > 0 ? 0 : -1);
+  }, [searchResult.totalMatches]);
+
+  // Visible segments (with virtual scrolling)
+  const visibleSegments = useMemo(() => {
+    if (virtualScrollThreshold === 0 || !isExpanded) {
+      return filteredSegments;
+    }
+    return filteredSegments.slice(0, visibleCount);
+  }, [filteredSegments, visibleCount, virtualScrollThreshold, isExpanded]);
+
+  // Handle search change
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchQuery(value);
+    setVisibleCount(virtualScrollThreshold || 100);
+  }, [virtualScrollThreshold]);
+
+  // Scroll to segment
+  const scrollToSegment = useCallback((segmentId: string) => {
+    const element = segmentRefs.current.get(segmentId);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      element.focus();
+    }
+  }, []);
+
+  // Navigate to match
+  const navigateToMatch = useCallback(
+    (index: number) => {
+      const match = searchResult.matches[index];
+      if (match) {
+        setCurrentMatchIndex(index);
+        scrollToSegment(match.segmentId);
+      }
+    },
+    [searchResult.matches, scrollToSegment]
+  );
+
+  // Handle previous/next navigation
+  const handlePrevious = useCallback(() => {
+    if (searchResult.totalMatches === 0) return;
+
+    const newIndex =
+      currentMatchIndex <= 0
+        ? searchResult.totalMatches - 1
+        : currentMatchIndex - 1;
+    navigateToMatch(newIndex);
+  }, [currentMatchIndex, searchResult.totalMatches, navigateToMatch]);
+
+  const handleNext = useCallback(() => {
+    if (searchResult.totalMatches === 0) return;
+
+    const newIndex =
+      currentMatchIndex >= searchResult.totalMatches - 1
+        ? 0
+        : currentMatchIndex + 1;
+    navigateToMatch(newIndex);
+  }, [currentMatchIndex, searchResult.totalMatches, navigateToMatch]);
+
+  // Toggle expand/collapse
+  const toggleExpanded = useCallback(() => {
+    setIsExpanded((prev) => !prev);
+  }, []);
+
+  // Load more segments (infinite scroll)
+  const handleLoadMore = useCallback(() => {
+    setVisibleCount((prev) => prev + (virtualScrollThreshold || 100));
+  }, [virtualScrollThreshold]);
+
+  // Intersection observer for infinite scroll
+  useEffect(() => {
+    if (
+      virtualScrollThreshold === 0 ||
+      visibleCount >= filteredSegments.length
+    ) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry !== undefined && entry.isIntersecting) {
+          handleLoadMore();
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    const sentinel = document.getElementById('transcript-load-more-sentinel');
+    if (sentinel) {
+      observer.observe(sentinel);
+    }
+
+    return (): void => {
+      observer.disconnect();
+    };
+  }, [virtualScrollThreshold, visibleCount, filteredSegments.length, handleLoadMore]);
+
+  // Register segment ref
+  const registerSegmentRef = useCallback(
+    (segmentId: string, element: HTMLElement | null) => {
+      if (element) {
+        segmentRefs.current.set(segmentId, element);
+      } else {
+        segmentRefs.current.delete(segmentId);
+      }
+    },
+    []
+  );
+
+  // Show loading state
+  if (isLoading) {
+    return <TranscriptSkeleton className={className} />;
+  }
+
+  // Show empty state
+  if (!transcript || transcript.segments.length === 0) {
+    return (
+      <div
+        className={`
+          bg-white rounded-lg border border-lark-border p-8
+          flex flex-col items-center justify-center text-center
+          ${className}
+        `}
+      >
+        <svg
+          className="w-12 h-12 text-gray-300 mb-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+        <p className="text-gray-500 text-sm">文字起こしはありません</p>
+      </div>
+    );
+  }
+
+  const displayTitle = meetingTitle ?? '文字起こし';
+  const hasMoreSegments = visibleCount < filteredSegments.length;
+  const showSearchNav =
+    searchQuery.length > 0 && searchResult.totalMatches >= 0;
+
+  // Get focused match info for highlighting
+  const focusedMatch =
+    currentMatchIndex >= 0 ? searchResult.matches[currentMatchIndex] : null;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`bg-white rounded-lg border border-lark-border ${className}`}
+      role="region"
+      aria-label={displayTitle}
+    >
+      {/* Header */}
+      <header className="p-4 border-b border-lark-border">
+        <div className="flex items-center justify-between gap-4">
+          {/* Title */}
+          <div className="flex items-center gap-2 min-w-0">
+            <svg
+              className="w-5 h-5 text-gray-500 flex-shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+              />
+            </svg>
+            <h2 className="text-lg font-medium text-lark-text truncate">
+              {displayTitle}
+            </h2>
+            <span className="text-sm text-gray-500 flex-shrink-0">
+              ({filteredSegments.length}件)
+            </span>
+          </div>
+
+          {/* Controls */}
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {/* Search input */}
+            <SearchInput
+              value={searchQuery}
+              onChange={handleSearchChange}
+              placeholder="文字起こしを検索..."
+              className="w-48"
+            />
+
+            {/* Expand/Collapse toggle */}
+            <button
+              type="button"
+              onClick={toggleExpanded}
+              className={`
+                flex items-center gap-1 px-3 py-2
+                text-sm text-gray-600
+                border border-lark-border rounded-lg
+                hover:bg-gray-50 transition-colors
+                focus:outline-none focus:ring-2 focus:ring-lark-primary focus:ring-offset-2
+              `}
+              aria-expanded={isExpanded}
+              aria-controls="transcript-segments"
+            >
+              {isExpanded ? '折りたたむ' : '展開'}
+              <svg
+                className={`w-4 h-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Search navigation */}
+        {showSearchNav && (
+          <div className="mt-3">
+            <TranscriptSearch
+              searchResult={{ ...searchResult, currentMatchIndex }}
+              onPrevious={handlePrevious}
+              onNext={handleNext}
+            />
+          </div>
+        )}
+      </header>
+
+      {/* Segments list */}
+      {isExpanded && (
+        <div
+          id="transcript-segments"
+          className="divide-y divide-gray-100 max-h-[600px] overflow-y-auto"
+          role="list"
+          aria-label="文字起こしセグメント一覧"
+        >
+          {visibleSegments.length === 0 ? (
+            <div className="p-8 text-center text-gray-500 text-sm">
+              {searchQuery
+                ? `「${searchQuery}」に一致する結果がありません`
+                : '表示するセグメントがありません'}
+            </div>
+          ) : (
+            <>
+              {visibleSegments.map((segment) => {
+                const segmentMatches = getSegmentMatches(
+                  segment.id,
+                  searchResult
+                );
+                const isFocusedSegment = focusedMatch?.segmentId === segment.id;
+
+                // Find focused match index within this segment
+                let focusedMatchIndexInSegment: number | undefined;
+                if (isFocusedSegment && focusedMatch !== null && focusedMatch !== undefined) {
+                  focusedMatchIndexInSegment = segmentMatches.findIndex(
+                    (m) =>
+                      m.startIndex === focusedMatch.startIndex &&
+                      m.endIndex === focusedMatch.endIndex
+                  );
+                  if (focusedMatchIndexInSegment === -1) {
+                    focusedMatchIndexInSegment = undefined;
+                  }
+                }
+
+                return (
+                  <div
+                    key={segment.id}
+                    ref={(el): void => {
+                      registerSegmentRef(segment.id, el);
+                    }}
+                    role="listitem"
+                  >
+                    <SpeakerSegment
+                      segment={segment}
+                      searchMatches={segmentMatches}
+                      focusedMatchIndex={focusedMatchIndexInSegment}
+                      onSegmentClick={onSegmentClick}
+                      className={isFocusedSegment ? 'bg-yellow-50' : ''}
+                    />
+                  </div>
+                );
+              })}
+
+              {/* Load more sentinel for infinite scroll */}
+              {hasMoreSegments && (
+                <div
+                  id="transcript-load-more-sentinel"
+                  className="p-4 text-center"
+                >
+                  <button
+                    type="button"
+                    onClick={handleLoadMore}
+                    className="text-sm text-lark-primary hover:underline focus:outline-none focus:ring-2 focus:ring-lark-primary focus:ring-offset-2 rounded"
+                  >
+                    さらに読み込む ({filteredSegments.length - visibleCount}件)
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export const TranscriptViewer = memo(TranscriptViewerInner);

--- a/src/components/transcript/index.ts
+++ b/src/components/transcript/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Transcript UI Components
+ *
+ * @description Components for displaying meeting transcripts with search,
+ *              speaker segments, and virtual scroll support.
+ * @module components/transcript
+ */
+
+// TranscriptViewer - Main component
+export { TranscriptViewer } from './TranscriptViewer';
+export type { TranscriptViewerProps } from './TranscriptViewer';
+
+// SpeakerSegment - Individual speaker utterance display
+export { SpeakerSegment } from './SpeakerSegment';
+export type { SpeakerSegmentProps } from './SpeakerSegment';
+
+// TranscriptSearch - Search result navigation
+export { TranscriptSearch } from './TranscriptSearch';
+export type { TranscriptSearchProps } from './TranscriptSearch';
+
+// TranscriptSkeleton - Loading states
+export {
+  TranscriptSkeleton,
+  TranscriptSegmentSkeleton,
+} from './TranscriptSkeleton';
+export type {
+  TranscriptSkeletonProps,
+  TranscriptSegmentSkeletonProps,
+} from './TranscriptSkeleton';

--- a/src/lib/lark/__tests__/transcript.test.ts
+++ b/src/lib/lark/__tests__/transcript.test.ts
@@ -1,0 +1,529 @@
+/**
+ * Transcript service unit tests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { LarkClient, LarkClientError } from '../client';
+import {
+  TranscriptClient,
+  TranscriptNotFoundError,
+  TranscriptApiError,
+  transformLarkSpeaker,
+  transformLarkTranscriptSegment,
+  transformLarkTranscript,
+  extractUniqueSpeakers,
+  calculateTotalDuration,
+} from '../transcript';
+import type { LarkConfig } from '@/types/lark';
+import type {
+  LarkSpeaker,
+  LarkTranscript,
+  LarkTranscriptSegment,
+} from '../types';
+
+// =============================================================================
+// Mock Data Factories
+// =============================================================================
+
+const createMockLarkSpeaker = (overrides: Partial<LarkSpeaker> = {}): LarkSpeaker => ({
+  user_id: 'user_001',
+  name: 'John Doe',
+  ...overrides,
+});
+
+const createMockLarkTranscriptSegment = (
+  overrides: Partial<LarkTranscriptSegment> = {}
+): LarkTranscriptSegment => ({
+  segment_id: 'seg_001',
+  start_time: 0,
+  end_time: 15200,
+  speaker: createMockLarkSpeaker(),
+  text: 'Hello, this is a test transcript.',
+  confidence: 0.95,
+  ...overrides,
+});
+
+const createMockLarkTranscript = (
+  overrides: Partial<LarkTranscript> = {}
+): LarkTranscript => ({
+  meeting_id: 'meeting_001',
+  language: 'ja',
+  segments: [
+    createMockLarkTranscriptSegment(),
+    createMockLarkTranscriptSegment({
+      segment_id: 'seg_002',
+      start_time: 15200,
+      end_time: 30000,
+      speaker: createMockLarkSpeaker({ user_id: 'user_002', name: 'Jane Smith' }),
+      text: 'Thank you for joining.',
+      confidence: 0.92,
+    }),
+  ],
+  ...overrides,
+});
+
+// =============================================================================
+// transformLarkSpeaker Tests
+// =============================================================================
+
+describe('transformLarkSpeaker', () => {
+  it('should transform Lark speaker to application Speaker format', () => {
+    const larkSpeaker = createMockLarkSpeaker();
+    const speaker = transformLarkSpeaker(larkSpeaker);
+
+    expect(speaker.id).toBe('user_001');
+    expect(speaker.name).toBe('John Doe');
+  });
+
+  it('should handle different user IDs', () => {
+    const larkSpeaker = createMockLarkSpeaker({
+      user_id: 'custom_user_123',
+      name: 'Custom User',
+    });
+    const speaker = transformLarkSpeaker(larkSpeaker);
+
+    expect(speaker.id).toBe('custom_user_123');
+    expect(speaker.name).toBe('Custom User');
+  });
+});
+
+// =============================================================================
+// transformLarkTranscriptSegment Tests
+// =============================================================================
+
+describe('transformLarkTranscriptSegment', () => {
+  it('should transform Lark segment to application TranscriptSegment format', () => {
+    const larkSegment = createMockLarkTranscriptSegment();
+    const segment = transformLarkTranscriptSegment(larkSegment);
+
+    expect(segment.id).toBe('seg_001');
+    expect(segment.startTimeMs).toBe(0);
+    expect(segment.endTimeMs).toBe(15200);
+    expect(segment.durationMs).toBe(15200);
+    expect(segment.speaker.id).toBe('user_001');
+    expect(segment.speaker.name).toBe('John Doe');
+    expect(segment.text).toBe('Hello, this is a test transcript.');
+    expect(segment.confidence).toBe(0.95);
+  });
+
+  it('should calculate duration correctly', () => {
+    const larkSegment = createMockLarkTranscriptSegment({
+      start_time: 5000,
+      end_time: 10000,
+    });
+    const segment = transformLarkTranscriptSegment(larkSegment);
+
+    expect(segment.durationMs).toBe(5000);
+  });
+
+  it('should handle missing confidence', () => {
+    const larkSegment = createMockLarkTranscriptSegment({
+      confidence: undefined,
+    });
+    const segment = transformLarkTranscriptSegment(larkSegment);
+
+    expect(segment.confidence).toBeUndefined();
+  });
+
+  it('should handle zero duration segment', () => {
+    const larkSegment = createMockLarkTranscriptSegment({
+      start_time: 1000,
+      end_time: 1000,
+    });
+    const segment = transformLarkTranscriptSegment(larkSegment);
+
+    expect(segment.durationMs).toBe(0);
+  });
+});
+
+// =============================================================================
+// extractUniqueSpeakers Tests
+// =============================================================================
+
+describe('extractUniqueSpeakers', () => {
+  it('should extract unique speakers from segments', () => {
+    const larkTranscript = createMockLarkTranscript();
+    const transcript = transformLarkTranscript(larkTranscript);
+    const speakers = extractUniqueSpeakers(transcript.segments);
+
+    expect(speakers).toHaveLength(2);
+    expect(speakers.map((s) => s.id)).toContain('user_001');
+    expect(speakers.map((s) => s.id)).toContain('user_002');
+  });
+
+  it('should return empty array for empty segments', () => {
+    const speakers = extractUniqueSpeakers([]);
+
+    expect(speakers).toHaveLength(0);
+  });
+
+  it('should deduplicate same speaker across multiple segments', () => {
+    const larkTranscript = createMockLarkTranscript({
+      segments: [
+        createMockLarkTranscriptSegment({ segment_id: 'seg_001' }),
+        createMockLarkTranscriptSegment({ segment_id: 'seg_002' }),
+        createMockLarkTranscriptSegment({ segment_id: 'seg_003' }),
+      ],
+    });
+    const transcript = transformLarkTranscript(larkTranscript);
+    const speakers = extractUniqueSpeakers(transcript.segments);
+
+    expect(speakers).toHaveLength(1);
+    expect(speakers[0]?.id).toBe('user_001');
+  });
+});
+
+// =============================================================================
+// calculateTotalDuration Tests
+// =============================================================================
+
+describe('calculateTotalDuration', () => {
+  it('should calculate total duration from segments', () => {
+    const larkTranscript = createMockLarkTranscript();
+    const transcript = transformLarkTranscript(larkTranscript);
+    const duration = calculateTotalDuration(transcript.segments);
+
+    expect(duration).toBe(30000); // Last segment ends at 30000ms
+  });
+
+  it('should return 0 for empty segments', () => {
+    const duration = calculateTotalDuration([]);
+
+    expect(duration).toBe(0);
+  });
+
+  it('should find maximum end time regardless of order', () => {
+    const larkTranscript = createMockLarkTranscript({
+      segments: [
+        createMockLarkTranscriptSegment({
+          segment_id: 'seg_001',
+          start_time: 50000,
+          end_time: 60000,
+        }),
+        createMockLarkTranscriptSegment({
+          segment_id: 'seg_002',
+          start_time: 0,
+          end_time: 10000,
+        }),
+      ],
+    });
+    const transcript = transformLarkTranscript(larkTranscript);
+    const duration = calculateTotalDuration(transcript.segments);
+
+    expect(duration).toBe(60000);
+  });
+});
+
+// =============================================================================
+// transformLarkTranscript Tests
+// =============================================================================
+
+describe('transformLarkTranscript', () => {
+  it('should transform Lark transcript to application Transcript format', () => {
+    const larkTranscript = createMockLarkTranscript();
+    const transcript = transformLarkTranscript(larkTranscript);
+
+    expect(transcript.meetingId).toBe('meeting_001');
+    expect(transcript.language).toBe('ja');
+    expect(transcript.segments).toHaveLength(2);
+    expect(transcript.segmentCount).toBe(2);
+    expect(transcript.totalDurationMs).toBe(30000);
+    expect(transcript.speakers).toHaveLength(2);
+  });
+
+  it('should handle empty segments', () => {
+    const larkTranscript = createMockLarkTranscript({ segments: [] });
+    const transcript = transformLarkTranscript(larkTranscript);
+
+    expect(transcript.segments).toHaveLength(0);
+    expect(transcript.segmentCount).toBe(0);
+    expect(transcript.totalDurationMs).toBe(0);
+    expect(transcript.speakers).toHaveLength(0);
+  });
+
+  it('should handle missing language', () => {
+    const larkTranscript = createMockLarkTranscript({ language: undefined });
+    const transcript = transformLarkTranscript(larkTranscript);
+
+    expect(transcript.language).toBeUndefined();
+  });
+
+  it('should preserve segment order', () => {
+    const larkTranscript = createMockLarkTranscript();
+    const transcript = transformLarkTranscript(larkTranscript);
+
+    expect(transcript.segments[0]?.id).toBe('seg_001');
+    expect(transcript.segments[1]?.id).toBe('seg_002');
+  });
+});
+
+// =============================================================================
+// TranscriptNotFoundError Tests
+// =============================================================================
+
+describe('TranscriptNotFoundError', () => {
+  it('should create error with meeting ID', () => {
+    const error = new TranscriptNotFoundError('meeting_123');
+
+    expect(error.meetingId).toBe('meeting_123');
+    expect(error.message).toBe('Transcript not found for meeting: meeting_123');
+    expect(error.name).toBe('TranscriptNotFoundError');
+  });
+
+  it('should accept custom message', () => {
+    const error = new TranscriptNotFoundError('meeting_123', 'Custom error message');
+
+    expect(error.message).toBe('Custom error message');
+    expect(error.meetingId).toBe('meeting_123');
+  });
+});
+
+// =============================================================================
+// TranscriptApiError Tests
+// =============================================================================
+
+describe('TranscriptApiError', () => {
+  it('should create error with details', () => {
+    const error = new TranscriptApiError(
+      'API failed',
+      500,
+      'getTranscript',
+      { extra: 'info' }
+    );
+
+    expect(error.message).toBe('API failed');
+    expect(error.code).toBe(500);
+    expect(error.operation).toBe('getTranscript');
+    expect(error.details).toEqual({ extra: 'info' });
+    expect(error.name).toBe('TranscriptApiError');
+  });
+
+  it('should create from LarkClientError', () => {
+    const clientError = new LarkClientError('Client error', 401, '/test', { log_id: '123' });
+    const apiError = TranscriptApiError.fromLarkClientError(clientError, 'testOperation');
+
+    expect(apiError.message).toBe('Client error');
+    expect(apiError.code).toBe(401);
+    expect(apiError.operation).toBe('testOperation');
+    expect(apiError.details).toEqual({ log_id: '123' });
+  });
+});
+
+// =============================================================================
+// TranscriptClient Tests
+// =============================================================================
+
+describe('TranscriptClient', () => {
+  const config: LarkConfig = {
+    appId: 'test_app_id',
+    appSecret: 'test_secret',
+    baseUrl: 'https://open.larksuite.com',
+    redirectUri: 'http://localhost:3000/api/auth/callback',
+  };
+
+  let client: LarkClient;
+  let transcriptClient: TranscriptClient;
+  const accessToken = 'test_access_token';
+
+  beforeEach(() => {
+    client = new LarkClient(config);
+    transcriptClient = new TranscriptClient(client);
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getTranscript', () => {
+    it('should fetch and transform transcript', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 0,
+          msg: 'success',
+          data: createMockLarkTranscript(),
+        }),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      const transcript = await transcriptClient.getTranscript(accessToken, 'meeting_001');
+
+      expect(transcript.meetingId).toBe('meeting_001');
+      expect(transcript.language).toBe('ja');
+      expect(transcript.segments).toHaveLength(2);
+      expect(transcript.speakers).toHaveLength(2);
+    });
+
+    it('should throw TranscriptNotFoundError when transcript not found', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 0,
+          msg: 'success',
+        }),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      await expect(
+        transcriptClient.getTranscript(accessToken, 'nonexistent')
+      ).rejects.toThrow(TranscriptNotFoundError);
+    });
+
+    it('should throw TranscriptNotFoundError on meeting not found error code', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 99991663,
+          msg: 'Meeting not found',
+        }),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      await expect(
+        transcriptClient.getTranscript(accessToken, 'invalid_id')
+      ).rejects.toThrow(TranscriptNotFoundError);
+    });
+
+    it('should throw TranscriptNotFoundError on resource not found error code', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 99991664,
+          msg: 'Resource not found',
+        }),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      await expect(
+        transcriptClient.getTranscript(accessToken, 'invalid_id')
+      ).rejects.toThrow(TranscriptNotFoundError);
+    });
+
+    it('should throw TranscriptNotFoundError on transcript not available error code', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 99991672,
+          msg: 'Transcript not available',
+        }),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      await expect(
+        transcriptClient.getTranscript(accessToken, 'no_transcript')
+      ).rejects.toThrow(TranscriptNotFoundError);
+    });
+
+    it('should throw TranscriptApiError on other API failures', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 99991400,
+          msg: 'Invalid token',
+        }),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      await expect(
+        transcriptClient.getTranscript(accessToken, 'meeting_001')
+      ).rejects.toThrow(TranscriptApiError);
+
+      await expect(
+        transcriptClient.getTranscript(accessToken, 'meeting_001')
+      ).rejects.toMatchObject({
+        operation: 'getTranscript',
+      });
+    });
+
+    it('should replace meeting ID in endpoint URL', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 0,
+          msg: 'success',
+          data: createMockLarkTranscript(),
+        }),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      await transcriptClient.getTranscript(accessToken, 'meeting_xyz');
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/meetings/meeting_xyz/transcript'),
+        expect.any(Object)
+      );
+    });
+
+    it('should include authorization header', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 0,
+          msg: 'success',
+          data: createMockLarkTranscript(),
+        }),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      await transcriptClient.getTranscript(accessToken, 'meeting_001');
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${accessToken}`,
+          }),
+        })
+      );
+    });
+  });
+
+  describe('hasTranscript', () => {
+    it('should return true when transcript exists', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 0,
+          msg: 'success',
+          data: createMockLarkTranscript(),
+        }),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      const result = await transcriptClient.hasTranscript(accessToken, 'meeting_001');
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when transcript not found', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 0,
+          msg: 'success',
+        }),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      const result = await transcriptClient.hasTranscript(accessToken, 'nonexistent');
+
+      expect(result).toBe(false);
+    });
+
+    it('should throw on non-NotFound errors', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 99991400,
+          msg: 'Invalid token',
+        }),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      await expect(
+        transcriptClient.hasTranscript(accessToken, 'meeting_001')
+      ).rejects.toThrow(TranscriptApiError);
+    });
+  });
+});

--- a/src/lib/lark/index.ts
+++ b/src/lib/lark/index.ts
@@ -41,5 +41,21 @@ export {
   type PaginationOptions,
 } from './meeting';
 
+// Transcript Service
+export {
+  TranscriptClient,
+  TranscriptNotFoundError,
+  TranscriptApiError,
+  createTranscriptClient,
+  transformLarkSpeaker,
+  transformLarkTranscriptSegment,
+  transformLarkTranscript,
+  extractUniqueSpeakers,
+  calculateTotalDuration,
+  type Speaker,
+  type TranscriptSegment,
+  type Transcript,
+} from './transcript';
+
 // Types
 export * from './types';

--- a/src/lib/lark/transcript.ts
+++ b/src/lib/lark/transcript.ts
@@ -1,0 +1,316 @@
+/**
+ * Transcript Service for Lark VC API
+ * @module lib/lark/transcript
+ */
+
+import type { LarkClient } from './client';
+import { LarkClientError } from './client';
+import {
+  type LarkTranscript,
+  type LarkTranscriptData,
+  type LarkTranscriptSegment,
+  type LarkSpeaker,
+  type LarkTranscriptLanguage,
+  larkTranscriptResponseSchema,
+  LarkVCApiEndpoints,
+} from './types';
+
+// =============================================================================
+// Error Classes
+// =============================================================================
+
+/**
+ * Error thrown when a transcript is not found
+ */
+export class TranscriptNotFoundError extends Error {
+  constructor(
+    public readonly meetingId: string,
+    message?: string
+  ) {
+    super(message ?? `Transcript not found for meeting: ${meetingId}`);
+    this.name = 'TranscriptNotFoundError';
+  }
+}
+
+/**
+ * Error thrown when a transcript API operation fails
+ */
+export class TranscriptApiError extends Error {
+  constructor(
+    message: string,
+    public readonly code: number,
+    public readonly operation: string,
+    public readonly details?: unknown
+  ) {
+    super(message);
+    this.name = 'TranscriptApiError';
+  }
+
+  /**
+   * Create from LarkClientError
+   */
+  static fromLarkClientError(
+    error: LarkClientError,
+    operation: string
+  ): TranscriptApiError {
+    return new TranscriptApiError(error.message, error.code, operation, error.details);
+  }
+}
+
+// =============================================================================
+// Application Types
+// =============================================================================
+
+/**
+ * Transformed speaker information for application use
+ */
+export interface Speaker {
+  /** User ID */
+  readonly id: string;
+  /** Display name */
+  readonly name: string;
+}
+
+/**
+ * Transformed transcript segment for application use
+ */
+export interface TranscriptSegment {
+  /** Unique segment identifier */
+  readonly id: string;
+  /** Start time in milliseconds */
+  readonly startTimeMs: number;
+  /** End time in milliseconds */
+  readonly endTimeMs: number;
+  /** Duration in milliseconds */
+  readonly durationMs: number;
+  /** Speaker information */
+  readonly speaker: Speaker;
+  /** Transcribed text content */
+  readonly text: string;
+  /** Confidence score (0.0 - 1.0), undefined if not available */
+  readonly confidence: number | undefined;
+}
+
+/**
+ * Complete transcript for application use
+ */
+export interface Transcript {
+  /** Meeting ID */
+  readonly meetingId: string;
+  /** Transcript language code */
+  readonly language: LarkTranscriptLanguage | undefined;
+  /** Array of transcript segments */
+  readonly segments: readonly TranscriptSegment[];
+  /** Total duration in milliseconds (based on last segment end time) */
+  readonly totalDurationMs: number;
+  /** Total number of segments */
+  readonly segmentCount: number;
+  /** Unique speakers in the transcript */
+  readonly speakers: readonly Speaker[];
+}
+
+// =============================================================================
+// Data Transformation Functions
+// =============================================================================
+
+/**
+ * Transform Lark speaker to application Speaker format
+ * @param larkSpeaker - Speaker data from Lark API
+ * @returns Transformed Speaker object
+ */
+export function transformLarkSpeaker(larkSpeaker: LarkSpeaker): Speaker {
+  return {
+    id: larkSpeaker.user_id,
+    name: larkSpeaker.name,
+  };
+}
+
+/**
+ * Transform Lark transcript segment to application TranscriptSegment format
+ * @param larkSegment - Segment data from Lark API
+ * @returns Transformed TranscriptSegment object
+ */
+export function transformLarkTranscriptSegment(
+  larkSegment: LarkTranscriptSegment
+): TranscriptSegment {
+  return {
+    id: larkSegment.segment_id,
+    startTimeMs: larkSegment.start_time,
+    endTimeMs: larkSegment.end_time,
+    durationMs: larkSegment.end_time - larkSegment.start_time,
+    speaker: transformLarkSpeaker(larkSegment.speaker),
+    text: larkSegment.text,
+    confidence: larkSegment.confidence,
+  };
+}
+
+/**
+ * Extract unique speakers from transcript segments
+ * @param segments - Array of transcript segments
+ * @returns Array of unique speakers
+ */
+export function extractUniqueSpeakers(
+  segments: readonly TranscriptSegment[]
+): readonly Speaker[] {
+  const speakerMap = new Map<string, Speaker>();
+
+  for (const segment of segments) {
+    if (!speakerMap.has(segment.speaker.id)) {
+      speakerMap.set(segment.speaker.id, segment.speaker);
+    }
+  }
+
+  return Array.from(speakerMap.values());
+}
+
+/**
+ * Calculate total duration from segments
+ * @param segments - Array of transcript segments
+ * @returns Total duration in milliseconds
+ */
+export function calculateTotalDuration(
+  segments: readonly TranscriptSegment[]
+): number {
+  if (segments.length === 0) {
+    return 0;
+  }
+
+  let maxEndTime = 0;
+  for (const segment of segments) {
+    if (segment.endTimeMs > maxEndTime) {
+      maxEndTime = segment.endTimeMs;
+    }
+  }
+
+  return maxEndTime;
+}
+
+/**
+ * Transform Lark transcript to application Transcript format
+ * @param larkTranscript - Transcript data from Lark API
+ * @returns Transformed Transcript object
+ */
+export function transformLarkTranscript(larkTranscript: LarkTranscript): Transcript {
+  const segments = larkTranscript.segments.map(transformLarkTranscriptSegment);
+  const speakers = extractUniqueSpeakers(segments);
+  const totalDurationMs = calculateTotalDuration(segments);
+
+  return {
+    meetingId: larkTranscript.meeting_id,
+    language: larkTranscript.language,
+    segments,
+    totalDurationMs,
+    segmentCount: segments.length,
+    speakers,
+  };
+}
+
+// =============================================================================
+// TranscriptClient Class
+// =============================================================================
+
+/**
+ * Client for interacting with Lark VC Transcript API
+ *
+ * Provides methods to fetch meeting transcripts from Lark API.
+ * Handles data transformation from Lark API format to application format.
+ *
+ * @example
+ * ```typescript
+ * const client = createLarkClient();
+ * const transcriptClient = new TranscriptClient(client);
+ *
+ * // Get transcript for a meeting
+ * const transcript = await transcriptClient.getTranscript(accessToken, 'meeting_id');
+ * console.log(`Found ${transcript.segmentCount} segments`);
+ *
+ * // Access segments
+ * for (const segment of transcript.segments) {
+ *   console.log(`${segment.speaker.name}: ${segment.text}`);
+ * }
+ * ```
+ */
+export class TranscriptClient {
+  private readonly client: LarkClient;
+
+  constructor(client: LarkClient) {
+    this.client = client;
+  }
+
+  /**
+   * Get transcript for a meeting
+   * @param accessToken - User access token
+   * @param meetingId - The meeting ID to fetch transcript for
+   * @returns Transcript data for the meeting
+   * @throws {TranscriptNotFoundError} When the transcript is not found
+   * @throws {TranscriptApiError} When the API request fails
+   */
+  async getTranscript(accessToken: string, meetingId: string): Promise<Transcript> {
+    try {
+      const endpoint = LarkVCApiEndpoints.TRANSCRIPT_GET.replace(
+        ':meeting_id',
+        meetingId
+      );
+
+      const response = await this.client.authenticatedRequest<LarkTranscriptData>(
+        endpoint,
+        accessToken
+      );
+
+      // Validate response with Zod
+      const validated = larkTranscriptResponseSchema.parse(response);
+
+      if (validated.data === undefined) {
+        throw new TranscriptNotFoundError(meetingId);
+      }
+
+      return transformLarkTranscript(validated.data);
+    } catch (error) {
+      if (error instanceof TranscriptNotFoundError) {
+        throw error;
+      }
+      if (error instanceof LarkClientError) {
+        // Check for not found error codes
+        // 99991663: Meeting not found
+        // 99991664: Resource not found
+        // 99991672: Transcript not available
+        if (
+          error.code === 99991663 ||
+          error.code === 99991664 ||
+          error.code === 99991672
+        ) {
+          throw new TranscriptNotFoundError(meetingId, error.message);
+        }
+        throw TranscriptApiError.fromLarkClientError(error, 'getTranscript');
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Check if a meeting has a transcript available
+   * @param accessToken - User access token
+   * @param meetingId - The meeting ID to check
+   * @returns True if transcript is available, false otherwise
+   */
+  async hasTranscript(accessToken: string, meetingId: string): Promise<boolean> {
+    try {
+      await this.getTranscript(accessToken, meetingId);
+      return true;
+    } catch (error) {
+      if (error instanceof TranscriptNotFoundError) {
+        return false;
+      }
+      throw error;
+    }
+  }
+}
+
+/**
+ * Create a TranscriptClient instance with the provided LarkClient
+ * @param client - LarkClient instance
+ * @returns New TranscriptClient instance
+ */
+export function createTranscriptClient(client: LarkClient): TranscriptClient {
+  return new TranscriptClient(client);
+}

--- a/src/lib/lark/types.ts
+++ b/src/lib/lark/types.ts
@@ -355,6 +355,90 @@ export const LarkVCApiEndpoints = {
   PARTICIPANT_LIST: '/open-apis/vc/v1/meetings/:meeting_id/participants',
   /** List meeting recordings */
   RECORDING_LIST: '/open-apis/vc/v1/meetings/:meeting_id/recordings',
+  /** Get meeting transcript */
+  TRANSCRIPT_GET: '/open-apis/vc/v1/meetings/:meeting_id/transcript',
 } as const;
 
 export type LarkVCApiEndpoint = (typeof LarkVCApiEndpoints)[keyof typeof LarkVCApiEndpoints];
+
+// =============================================================================
+// Lark VC Transcript API Types
+// =============================================================================
+
+/**
+ * Speaker information in transcript segment
+ */
+export const larkSpeakerSchema = z.object({
+  /** User ID of the speaker */
+  user_id: z.string(),
+  /** Display name of the speaker */
+  name: z.string(),
+});
+
+export type LarkSpeaker = z.infer<typeof larkSpeakerSchema>;
+
+/**
+ * Single transcript segment
+ */
+export const larkTranscriptSegmentSchema = z.object({
+  /** Unique segment identifier */
+  segment_id: z.string(),
+  /** Start time in milliseconds from meeting start */
+  start_time: z.number(),
+  /** End time in milliseconds from meeting start */
+  end_time: z.number(),
+  /** Speaker information */
+  speaker: larkSpeakerSchema,
+  /** Transcribed text content */
+  text: z.string(),
+  /** Confidence score (0.0 - 1.0) */
+  confidence: z.number().min(0).max(1).optional(),
+});
+
+export type LarkTranscriptSegment = z.infer<typeof larkTranscriptSegmentSchema>;
+
+/**
+ * Supported transcript languages
+ */
+export const larkTranscriptLanguageSchema = z.enum([
+  'ja',
+  'en',
+  'zh',
+  'ko',
+  'de',
+  'fr',
+  'es',
+  'pt',
+  'it',
+  'ru',
+]);
+
+export type LarkTranscriptLanguage = z.infer<typeof larkTranscriptLanguageSchema>;
+
+/**
+ * Complete transcript data for a meeting
+ */
+export const larkTranscriptSchema = z.object({
+  /** Meeting ID */
+  meeting_id: z.string(),
+  /** Transcript language */
+  language: larkTranscriptLanguageSchema.optional(),
+  /** Array of transcript segments */
+  segments: z.array(larkTranscriptSegmentSchema),
+});
+
+export type LarkTranscript = z.infer<typeof larkTranscriptSchema>;
+
+/**
+ * Transcript response data from Lark API
+ */
+export const larkTranscriptDataSchema = larkTranscriptSchema;
+
+export type LarkTranscriptData = z.infer<typeof larkTranscriptDataSchema>;
+
+/**
+ * Transcript API response
+ */
+export const larkTranscriptResponseSchema = larkApiResponseSchema(larkTranscriptDataSchema);
+
+export type LarkTranscriptResponse = z.infer<typeof larkTranscriptResponseSchema>;

--- a/src/services/__tests__/transcript.service.test.ts
+++ b/src/services/__tests__/transcript.service.test.ts
@@ -1,0 +1,565 @@
+/**
+ * TranscriptService unit tests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  TranscriptService,
+  TranscriptServiceError,
+  TranscriptNotFoundError,
+  transformToAppSpeaker,
+  transformToAppSegment,
+  transformToAppTranscript,
+} from '../transcript.service';
+import {
+  TranscriptClient,
+  TranscriptApiError,
+  type Transcript as LarkTranscript,
+  type TranscriptSegment as LarkTranscriptSegment,
+  type Speaker as LarkSpeaker,
+} from '@/lib/lark';
+
+// =============================================================================
+// Mock Data Factories
+// =============================================================================
+
+const createMockLarkSpeaker = (
+  overrides: Partial<LarkSpeaker> = {}
+): LarkSpeaker => ({
+  id: 'user_001',
+  name: 'John Doe',
+  ...overrides,
+});
+
+const createMockLarkTranscriptSegment = (
+  overrides: Partial<LarkTranscriptSegment> = {}
+): LarkTranscriptSegment => ({
+  id: 'seg_001',
+  startTimeMs: 0,
+  endTimeMs: 15200,
+  durationMs: 15200,
+  speaker: createMockLarkSpeaker(),
+  text: 'Hello, this is a test transcript.',
+  confidence: 0.95,
+  ...overrides,
+});
+
+const createMockLarkTranscript = (
+  overrides: Partial<LarkTranscript> = {}
+): LarkTranscript => ({
+  meetingId: 'meeting_001',
+  language: 'ja',
+  segments: [
+    createMockLarkTranscriptSegment(),
+    createMockLarkTranscriptSegment({
+      id: 'seg_002',
+      startTimeMs: 15200,
+      endTimeMs: 30000,
+      durationMs: 14800,
+      speaker: createMockLarkSpeaker({ id: 'user_002', name: 'Jane Smith' }),
+      text: 'Thank you for joining.',
+      confidence: 0.92,
+    }),
+  ],
+  totalDurationMs: 30000,
+  segmentCount: 2,
+  speakers: [
+    createMockLarkSpeaker(),
+    createMockLarkSpeaker({ id: 'user_002', name: 'Jane Smith' }),
+  ],
+  ...overrides,
+});
+
+// =============================================================================
+// transformToAppSpeaker Tests
+// =============================================================================
+
+describe('transformToAppSpeaker', () => {
+  it('should transform Lark speaker to application Speaker format', () => {
+    const larkSpeaker = createMockLarkSpeaker();
+    const speaker = transformToAppSpeaker(larkSpeaker);
+
+    expect(speaker.id).toBe('user_001');
+    expect(speaker.name).toBe('John Doe');
+  });
+
+  it('should handle different user IDs and names', () => {
+    const larkSpeaker = createMockLarkSpeaker({
+      id: 'custom_user_123',
+      name: 'Custom User',
+    });
+    const speaker = transformToAppSpeaker(larkSpeaker);
+
+    expect(speaker.id).toBe('custom_user_123');
+    expect(speaker.name).toBe('Custom User');
+  });
+
+  it('should not include avatarUrl (not provided by Lark API)', () => {
+    const larkSpeaker = createMockLarkSpeaker();
+    const speaker = transformToAppSpeaker(larkSpeaker);
+
+    expect(speaker.avatarUrl).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// transformToAppSegment Tests
+// =============================================================================
+
+describe('transformToAppSegment', () => {
+  it('should transform Lark segment to application TranscriptSegment format', () => {
+    const larkSegment = createMockLarkTranscriptSegment();
+    const segment = transformToAppSegment(larkSegment);
+
+    expect(segment.id).toBe('seg_001');
+    expect(segment.startTime).toBe(0);
+    expect(segment.endTime).toBe(15200);
+    expect(segment.speaker.id).toBe('user_001');
+    expect(segment.speaker.name).toBe('John Doe');
+    expect(segment.text).toBe('Hello, this is a test transcript.');
+    expect(segment.confidence).toBe(0.95);
+  });
+
+  it('should map startTimeMs to startTime and endTimeMs to endTime', () => {
+    const larkSegment = createMockLarkTranscriptSegment({
+      startTimeMs: 5000,
+      endTimeMs: 10000,
+    });
+    const segment = transformToAppSegment(larkSegment);
+
+    expect(segment.startTime).toBe(5000);
+    expect(segment.endTime).toBe(10000);
+  });
+
+  it('should default confidence to 0 when undefined', () => {
+    const larkSegment = createMockLarkTranscriptSegment({
+      confidence: undefined,
+    });
+    const segment = transformToAppSegment(larkSegment);
+
+    expect(segment.confidence).toBe(0);
+  });
+
+  it('should preserve confidence when provided', () => {
+    const larkSegment = createMockLarkTranscriptSegment({
+      confidence: 0.88,
+    });
+    const segment = transformToAppSegment(larkSegment);
+
+    expect(segment.confidence).toBe(0.88);
+  });
+});
+
+// =============================================================================
+// transformToAppTranscript Tests
+// =============================================================================
+
+describe('transformToAppTranscript', () => {
+  it('should transform Lark transcript to application Transcript format', () => {
+    const larkTranscript = createMockLarkTranscript();
+    const transcript = transformToAppTranscript(larkTranscript);
+
+    expect(transcript.meetingId).toBe('meeting_001');
+    expect(transcript.language).toBe('ja');
+    expect(transcript.segments).toHaveLength(2);
+    expect(transcript.totalDuration).toBe(30000);
+    expect(transcript.createdAt).toBeDefined();
+  });
+
+  it('should map totalDurationMs to totalDuration', () => {
+    const larkTranscript = createMockLarkTranscript({
+      totalDurationMs: 60000,
+    });
+    const transcript = transformToAppTranscript(larkTranscript);
+
+    expect(transcript.totalDuration).toBe(60000);
+  });
+
+  it('should default language to empty string when undefined', () => {
+    const larkTranscript = createMockLarkTranscript({
+      language: undefined,
+    });
+    const transcript = transformToAppTranscript(larkTranscript);
+
+    expect(transcript.language).toBe('');
+  });
+
+  it('should generate valid ISO 8601 createdAt timestamp', () => {
+    const larkTranscript = createMockLarkTranscript();
+    const transcript = transformToAppTranscript(larkTranscript);
+
+    // Should be a valid ISO 8601 date string
+    const parsedDate = new Date(transcript.createdAt);
+    expect(parsedDate.toISOString()).toBe(transcript.createdAt);
+  });
+
+  it('should transform all segments', () => {
+    const larkTranscript = createMockLarkTranscript();
+    const transcript = transformToAppTranscript(larkTranscript);
+
+    expect(transcript.segments[0]?.id).toBe('seg_001');
+    expect(transcript.segments[0]?.startTime).toBe(0);
+    expect(transcript.segments[1]?.id).toBe('seg_002');
+    expect(transcript.segments[1]?.startTime).toBe(15200);
+  });
+
+  it('should handle empty segments array', () => {
+    const larkTranscript = createMockLarkTranscript({
+      segments: [],
+      segmentCount: 0,
+      speakers: [],
+    });
+    const transcript = transformToAppTranscript(larkTranscript);
+
+    expect(transcript.segments).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// TranscriptServiceError Tests
+// =============================================================================
+
+describe('TranscriptServiceError', () => {
+  it('should create error with all properties', () => {
+    const error = new TranscriptServiceError(
+      'Test error message',
+      'TEST_CODE',
+      400,
+      { extra: 'info' }
+    );
+
+    expect(error.message).toBe('Test error message');
+    expect(error.code).toBe('TEST_CODE');
+    expect(error.statusCode).toBe(400);
+    expect(error.details).toEqual({ extra: 'info' });
+    expect(error.name).toBe('TranscriptServiceError');
+  });
+
+  it('should default statusCode to 500', () => {
+    const error = new TranscriptServiceError('Error', 'CODE');
+
+    expect(error.statusCode).toBe(500);
+  });
+});
+
+// =============================================================================
+// TranscriptService Tests
+// =============================================================================
+
+describe('TranscriptService', () => {
+  let mockTranscriptClient: TranscriptClient;
+  let service: TranscriptService;
+  const accessToken = 'test_access_token';
+
+  beforeEach(() => {
+    // Create mock TranscriptClient
+    mockTranscriptClient = {
+      getTranscript: vi.fn(),
+      hasTranscript: vi.fn(),
+    } as unknown as TranscriptClient;
+
+    service = new TranscriptService(mockTranscriptClient);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getTranscript', () => {
+    it('should fetch and transform transcript to application format', async () => {
+      const mockLarkTranscript = createMockLarkTranscript();
+      vi.mocked(mockTranscriptClient.getTranscript).mockResolvedValue(
+        mockLarkTranscript
+      );
+
+      const transcript = await service.getTranscript(accessToken, 'meeting_001');
+
+      expect(mockTranscriptClient.getTranscript).toHaveBeenCalledWith(
+        accessToken,
+        'meeting_001'
+      );
+      expect(transcript.meetingId).toBe('meeting_001');
+      expect(transcript.language).toBe('ja');
+      expect(transcript.segments).toHaveLength(2);
+      expect(transcript.totalDuration).toBe(30000);
+      expect(transcript.createdAt).toBeDefined();
+    });
+
+    it('should transform segments with correct field mapping', async () => {
+      const mockLarkTranscript = createMockLarkTranscript();
+      vi.mocked(mockTranscriptClient.getTranscript).mockResolvedValue(
+        mockLarkTranscript
+      );
+
+      const transcript = await service.getTranscript(accessToken, 'meeting_001');
+
+      const firstSegment = transcript.segments[0];
+      expect(firstSegment?.startTime).toBe(0); // mapped from startTimeMs
+      expect(firstSegment?.endTime).toBe(15200); // mapped from endTimeMs
+    });
+
+    it('should re-throw TranscriptNotFoundError directly', async () => {
+      const notFoundError = new TranscriptNotFoundError('meeting_001');
+      vi.mocked(mockTranscriptClient.getTranscript).mockRejectedValue(
+        notFoundError
+      );
+
+      await expect(
+        service.getTranscript(accessToken, 'meeting_001')
+      ).rejects.toThrow(TranscriptNotFoundError);
+
+      await expect(
+        service.getTranscript(accessToken, 'meeting_001')
+      ).rejects.toThrow('Transcript not found for meeting: meeting_001');
+    });
+
+    it('should wrap TranscriptApiError in TranscriptServiceError', async () => {
+      const apiError = new TranscriptApiError(
+        'API error',
+        401,
+        'getTranscript',
+        { log_id: '123' }
+      );
+      vi.mocked(mockTranscriptClient.getTranscript).mockRejectedValue(apiError);
+
+      await expect(
+        service.getTranscript(accessToken, 'meeting_001')
+      ).rejects.toThrow(TranscriptServiceError);
+
+      await expect(
+        service.getTranscript(accessToken, 'meeting_001')
+      ).rejects.toMatchObject({
+        code: 'TRANSCRIPT_API_ERROR',
+        statusCode: 401,
+      });
+    });
+
+    it('should use 500 for non-HTTP error codes from TranscriptApiError', async () => {
+      const apiError = new TranscriptApiError(
+        'Internal error',
+        99991000,
+        'getTranscript'
+      );
+      vi.mocked(mockTranscriptClient.getTranscript).mockRejectedValue(apiError);
+
+      await expect(
+        service.getTranscript(accessToken, 'meeting_001')
+      ).rejects.toMatchObject({
+        statusCode: 500,
+      });
+    });
+
+    it('should wrap unknown errors in TranscriptServiceError', async () => {
+      vi.mocked(mockTranscriptClient.getTranscript).mockRejectedValue(
+        new Error('Unknown error')
+      );
+
+      await expect(
+        service.getTranscript(accessToken, 'meeting_001')
+      ).rejects.toThrow(TranscriptServiceError);
+
+      await expect(
+        service.getTranscript(accessToken, 'meeting_001')
+      ).rejects.toMatchObject({
+        code: 'UNKNOWN_ERROR',
+        statusCode: 500,
+      });
+    });
+
+    it('should handle non-Error thrown values', async () => {
+      vi.mocked(mockTranscriptClient.getTranscript).mockRejectedValue(
+        'string error'
+      );
+
+      await expect(
+        service.getTranscript(accessToken, 'meeting_001')
+      ).rejects.toThrow(TranscriptServiceError);
+
+      await expect(
+        service.getTranscript(accessToken, 'meeting_001')
+      ).rejects.toMatchObject({
+        details: { originalError: 'string error' },
+      });
+    });
+  });
+
+  describe('hasTranscript', () => {
+    it('should return true when transcript exists', async () => {
+      vi.mocked(mockTranscriptClient.hasTranscript).mockResolvedValue(true);
+
+      const result = await service.hasTranscript(accessToken, 'meeting_001');
+
+      expect(mockTranscriptClient.hasTranscript).toHaveBeenCalledWith(
+        accessToken,
+        'meeting_001'
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should return false when transcript does not exist', async () => {
+      vi.mocked(mockTranscriptClient.hasTranscript).mockResolvedValue(false);
+
+      const result = await service.hasTranscript(accessToken, 'meeting_001');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false for TranscriptNotFoundError', async () => {
+      vi.mocked(mockTranscriptClient.hasTranscript).mockRejectedValue(
+        new TranscriptNotFoundError('meeting_001')
+      );
+
+      const result = await service.hasTranscript(accessToken, 'meeting_001');
+
+      expect(result).toBe(false);
+    });
+
+    it('should wrap TranscriptApiError in TranscriptServiceError', async () => {
+      const apiError = new TranscriptApiError(
+        'API error',
+        403,
+        'hasTranscript'
+      );
+      vi.mocked(mockTranscriptClient.hasTranscript).mockRejectedValue(apiError);
+
+      await expect(
+        service.hasTranscript(accessToken, 'meeting_001')
+      ).rejects.toThrow(TranscriptServiceError);
+
+      await expect(
+        service.hasTranscript(accessToken, 'meeting_001')
+      ).rejects.toMatchObject({
+        code: 'TRANSCRIPT_API_ERROR',
+        statusCode: 403,
+      });
+    });
+
+    it('should wrap unknown errors in TranscriptServiceError', async () => {
+      vi.mocked(mockTranscriptClient.hasTranscript).mockRejectedValue(
+        new Error('Network error')
+      );
+
+      await expect(
+        service.hasTranscript(accessToken, 'meeting_001')
+      ).rejects.toThrow(TranscriptServiceError);
+
+      await expect(
+        service.hasTranscript(accessToken, 'meeting_001')
+      ).rejects.toMatchObject({
+        code: 'UNKNOWN_ERROR',
+      });
+    });
+  });
+});
+
+// =============================================================================
+// Integration-like Tests (Data Flow)
+// =============================================================================
+
+describe('TranscriptService data transformation flow', () => {
+  let mockTranscriptClient: TranscriptClient;
+  let service: TranscriptService;
+
+  beforeEach(() => {
+    mockTranscriptClient = {
+      getTranscript: vi.fn(),
+      hasTranscript: vi.fn(),
+    } as unknown as TranscriptClient;
+
+    service = new TranscriptService(mockTranscriptClient);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should correctly transform complete transcript with multiple speakers', async () => {
+    const larkTranscript = createMockLarkTranscript({
+      meetingId: 'meeting_xyz',
+      language: 'en',
+      segments: [
+        createMockLarkTranscriptSegment({
+          id: 'seg_1',
+          startTimeMs: 0,
+          endTimeMs: 10000,
+          speaker: createMockLarkSpeaker({ id: 'speaker_a', name: 'Alice' }),
+          text: 'Hello everyone',
+          confidence: 0.98,
+        }),
+        createMockLarkTranscriptSegment({
+          id: 'seg_2',
+          startTimeMs: 10000,
+          endTimeMs: 25000,
+          speaker: createMockLarkSpeaker({ id: 'speaker_b', name: 'Bob' }),
+          text: 'Hi Alice, nice to meet you',
+          confidence: 0.95,
+        }),
+        createMockLarkTranscriptSegment({
+          id: 'seg_3',
+          startTimeMs: 25000,
+          endTimeMs: 40000,
+          speaker: createMockLarkSpeaker({ id: 'speaker_a', name: 'Alice' }),
+          text: 'Let us begin the meeting',
+          confidence: undefined,
+        }),
+      ],
+      totalDurationMs: 40000,
+      segmentCount: 3,
+      speakers: [
+        createMockLarkSpeaker({ id: 'speaker_a', name: 'Alice' }),
+        createMockLarkSpeaker({ id: 'speaker_b', name: 'Bob' }),
+      ],
+    });
+
+    vi.mocked(mockTranscriptClient.getTranscript).mockResolvedValue(
+      larkTranscript
+    );
+
+    const transcript = await service.getTranscript('token', 'meeting_xyz');
+
+    // Verify top-level properties
+    expect(transcript.meetingId).toBe('meeting_xyz');
+    expect(transcript.language).toBe('en');
+    expect(transcript.totalDuration).toBe(40000);
+    expect(transcript.segments).toHaveLength(3);
+
+    // Verify segment transformations
+    expect(transcript.segments[0]?.startTime).toBe(0);
+    expect(transcript.segments[0]?.endTime).toBe(10000);
+    expect(transcript.segments[0]?.speaker.name).toBe('Alice');
+    expect(transcript.segments[0]?.confidence).toBe(0.98);
+
+    expect(transcript.segments[1]?.speaker.name).toBe('Bob');
+    expect(transcript.segments[1]?.text).toBe('Hi Alice, nice to meet you');
+
+    // Verify undefined confidence defaults to 0
+    expect(transcript.segments[2]?.confidence).toBe(0);
+
+    // Verify createdAt is a valid timestamp
+    expect(new Date(transcript.createdAt).toISOString()).toBe(
+      transcript.createdAt
+    );
+  });
+
+  it('should handle empty transcript', async () => {
+    const larkTranscript = createMockLarkTranscript({
+      meetingId: 'empty_meeting',
+      language: undefined,
+      segments: [],
+      totalDurationMs: 0,
+      segmentCount: 0,
+      speakers: [],
+    });
+
+    vi.mocked(mockTranscriptClient.getTranscript).mockResolvedValue(
+      larkTranscript
+    );
+
+    const transcript = await service.getTranscript('token', 'empty_meeting');
+
+    expect(transcript.meetingId).toBe('empty_meeting');
+    expect(transcript.language).toBe('');
+    expect(transcript.segments).toHaveLength(0);
+    expect(transcript.totalDuration).toBe(0);
+  });
+});

--- a/src/services/transcript.service.ts
+++ b/src/services/transcript.service.ts
@@ -1,0 +1,246 @@
+/**
+ * TranscriptService - Application layer transcript service
+ * @module services/transcript.service
+ *
+ * Provides high-level transcript operations with data transformation
+ * from Lark API format to application internal format.
+ */
+
+import {
+  TranscriptClient,
+  createTranscriptClient,
+  TranscriptNotFoundError,
+  TranscriptApiError,
+  type Transcript as LarkTranscript,
+  type TranscriptSegment as LarkTranscriptSegment,
+  type Speaker as LarkSpeaker,
+} from '@/lib/lark';
+import { createLarkClient, type LarkClient } from '@/lib/lark';
+import type {
+  Transcript,
+  TranscriptSegment,
+  Speaker,
+} from '@/types/transcript';
+
+// =============================================================================
+// Error Classes
+// =============================================================================
+
+/**
+ * Error thrown when a transcript service operation fails
+ */
+export class TranscriptServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly statusCode: number = 500,
+    public readonly details?: unknown
+  ) {
+    super(message);
+    this.name = 'TranscriptServiceError';
+  }
+}
+
+// =============================================================================
+// Data Transformation Functions
+// =============================================================================
+
+/**
+ * Transform Lark speaker to application Speaker format
+ * @param larkSpeaker - Speaker from Lark TranscriptClient
+ * @returns Application Speaker format
+ */
+export function transformToAppSpeaker(larkSpeaker: LarkSpeaker): Speaker {
+  return {
+    id: larkSpeaker.id,
+    name: larkSpeaker.name,
+    // avatarUrl is not provided by Lark API, so we omit it
+  };
+}
+
+/**
+ * Transform Lark transcript segment to application TranscriptSegment format
+ *
+ * Key transformations:
+ * - startTimeMs -> startTime
+ * - endTimeMs -> endTime
+ * - confidence: undefined becomes 0
+ *
+ * @param larkSegment - Segment from Lark TranscriptClient
+ * @returns Application TranscriptSegment format
+ */
+export function transformToAppSegment(
+  larkSegment: LarkTranscriptSegment
+): TranscriptSegment {
+  return {
+    id: larkSegment.id,
+    startTime: larkSegment.startTimeMs,
+    endTime: larkSegment.endTimeMs,
+    speaker: transformToAppSpeaker(larkSegment.speaker),
+    text: larkSegment.text,
+    confidence: larkSegment.confidence ?? 0,
+  };
+}
+
+/**
+ * Transform Lark transcript to application Transcript format
+ *
+ * Key transformations:
+ * - language: undefined becomes empty string
+ * - totalDurationMs -> totalDuration
+ * - segments: each segment is transformed
+ * - createdAt: generated as current ISO timestamp
+ *
+ * @param larkTranscript - Transcript from Lark TranscriptClient
+ * @returns Application Transcript format
+ */
+export function transformToAppTranscript(
+  larkTranscript: LarkTranscript
+): Transcript {
+  return {
+    meetingId: larkTranscript.meetingId,
+    language: larkTranscript.language ?? '',
+    segments: larkTranscript.segments.map(transformToAppSegment),
+    totalDuration: larkTranscript.totalDurationMs,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+// =============================================================================
+// TranscriptService Class
+// =============================================================================
+
+/**
+ * Application layer service for transcript operations
+ *
+ * Wraps the Lark TranscriptClient and provides:
+ * - Data transformation from Lark format to application format
+ * - Unified error handling
+ * - High-level business logic
+ *
+ * @example
+ * ```typescript
+ * const service = createTranscriptService();
+ *
+ * // Check if transcript exists
+ * const hasTranscript = await service.hasTranscript(accessToken, meetingId);
+ *
+ * // Get transcript
+ * if (hasTranscript) {
+ *   const transcript = await service.getTranscript(accessToken, meetingId);
+ *   console.log(`Found ${transcript.segments.length} segments`);
+ * }
+ * ```
+ */
+export class TranscriptService {
+  private readonly client: TranscriptClient;
+
+  constructor(client: TranscriptClient) {
+    this.client = client;
+  }
+
+  /**
+   * Get transcript for a meeting
+   *
+   * Fetches the transcript from Lark API and transforms it to application format.
+   *
+   * @param accessToken - User access token
+   * @param meetingId - Meeting ID to fetch transcript for
+   * @returns Transcript in application format
+   * @throws {TranscriptServiceError} When the API call fails
+   * @throws {TranscriptNotFoundError} When the transcript is not found
+   */
+  async getTranscript(accessToken: string, meetingId: string): Promise<Transcript> {
+    try {
+      const larkTranscript = await this.client.getTranscript(accessToken, meetingId);
+      return transformToAppTranscript(larkTranscript);
+    } catch (error) {
+      if (error instanceof TranscriptNotFoundError) {
+        throw error;
+      }
+
+      if (error instanceof TranscriptApiError) {
+        throw new TranscriptServiceError(
+          error.message,
+          'TRANSCRIPT_API_ERROR',
+          error.code >= 400 && error.code < 600 ? error.code : 500,
+          { operation: error.operation, details: error.details }
+        );
+      }
+
+      throw new TranscriptServiceError(
+        'Failed to fetch transcript',
+        'UNKNOWN_ERROR',
+        500,
+        { originalError: error instanceof Error ? error.message : String(error) }
+      );
+    }
+  }
+
+  /**
+   * Check if a meeting has a transcript available
+   *
+   * @param accessToken - User access token
+   * @param meetingId - Meeting ID to check
+   * @returns True if transcript is available, false otherwise
+   * @throws {TranscriptServiceError} When the API call fails (except for not found)
+   */
+  async hasTranscript(accessToken: string, meetingId: string): Promise<boolean> {
+    try {
+      return await this.client.hasTranscript(accessToken, meetingId);
+    } catch (error) {
+      if (error instanceof TranscriptNotFoundError) {
+        return false;
+      }
+
+      if (error instanceof TranscriptApiError) {
+        throw new TranscriptServiceError(
+          error.message,
+          'TRANSCRIPT_API_ERROR',
+          error.code >= 400 && error.code < 600 ? error.code : 500,
+          { operation: error.operation, details: error.details }
+        );
+      }
+
+      throw new TranscriptServiceError(
+        'Failed to check transcript availability',
+        'UNKNOWN_ERROR',
+        500,
+        { originalError: error instanceof Error ? error.message : String(error) }
+      );
+    }
+  }
+}
+
+// =============================================================================
+// Factory Functions
+// =============================================================================
+
+/**
+ * Create a TranscriptService instance with default LarkClient
+ *
+ * Uses environment variables for Lark API configuration.
+ *
+ * @returns TranscriptService instance
+ */
+export function createTranscriptService(): TranscriptService {
+  const larkClient = createLarkClient();
+  const transcriptClient = createTranscriptClient(larkClient);
+  return new TranscriptService(transcriptClient);
+}
+
+/**
+ * Create a TranscriptService instance with custom LarkClient
+ *
+ * @param larkClient - Custom LarkClient instance
+ * @returns TranscriptService instance
+ */
+export function createTranscriptServiceWithClient(
+  larkClient: LarkClient
+): TranscriptService {
+  const transcriptClient = createTranscriptClient(larkClient);
+  return new TranscriptService(transcriptClient);
+}
+
+// Re-export error classes for convenience
+export { TranscriptNotFoundError } from '@/lib/lark';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,3 +6,4 @@
 export * from './auth';
 export * from './lark';
 export * from './meeting';
+export * from './transcript';

--- a/src/types/transcript.ts
+++ b/src/types/transcript.ts
@@ -1,0 +1,383 @@
+/**
+ * Transcript related type definitions
+ * @module types/transcript
+ */
+
+import { createElement, type ReactNode } from 'react';
+
+// ============================================================================
+// Core Types
+// ============================================================================
+
+/**
+ * Speaker information in a transcript
+ */
+export interface Speaker {
+  /** Unique speaker identifier */
+  readonly id: string;
+  /** Speaker display name */
+  readonly name: string;
+  /** Speaker avatar URL */
+  readonly avatarUrl?: string | undefined;
+}
+
+/**
+ * A single segment of the transcript (a spoken utterance)
+ */
+export interface TranscriptSegment {
+  /** Unique segment identifier */
+  readonly id: string;
+  /** Start time in milliseconds from meeting start */
+  readonly startTime: number;
+  /** End time in milliseconds from meeting start */
+  readonly endTime: number;
+  /** Speaker information */
+  readonly speaker: Speaker;
+  /** Transcribed text content */
+  readonly text: string;
+  /** Confidence score from speech recognition (0-1) */
+  readonly confidence: number;
+}
+
+/**
+ * Complete transcript for a meeting
+ */
+export interface Transcript {
+  /** Associated meeting identifier */
+  readonly meetingId: string;
+  /** Language code (e.g., "ja", "en", "zh") */
+  readonly language: string;
+  /** Ordered list of transcript segments */
+  readonly segments: readonly TranscriptSegment[];
+  /** Total meeting duration in milliseconds */
+  readonly totalDuration: number;
+  /** Transcript creation timestamp in ISO 8601 format */
+  readonly createdAt: string;
+}
+
+// ============================================================================
+// Filter Types
+// ============================================================================
+
+/**
+ * Filter conditions for searching and filtering transcript segments
+ */
+export interface TranscriptFilters {
+  /** Text search query to match against segment text */
+  readonly searchQuery?: string | undefined;
+  /** Filter by specific speaker ID */
+  readonly speakerId?: string | undefined;
+  /** Filter segments starting from this time (milliseconds) */
+  readonly startTime?: number | undefined;
+  /** Filter segments ending before this time (milliseconds) */
+  readonly endTime?: number | undefined;
+}
+
+// ============================================================================
+// Search Result Types (for advanced search UI)
+// ============================================================================
+
+/**
+ * Search match information for highlighting
+ */
+export interface TranscriptSearchMatch {
+  /** Segment ID containing the match */
+  readonly segmentId: string;
+  /** Start index of match in segment text */
+  readonly startIndex: number;
+  /** End index of match in segment text */
+  readonly endIndex: number;
+}
+
+/**
+ * Transcript search result
+ */
+export interface TranscriptSearchResult {
+  /** Search query */
+  readonly query: string;
+  /** Total number of matches */
+  readonly totalMatches: number;
+  /** List of match details */
+  readonly matches: readonly TranscriptSearchMatch[];
+  /** Currently focused match index (0-based) */
+  readonly currentMatchIndex: number;
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Format a timestamp in milliseconds to "MM:SS" or "HH:MM:SS" format
+ *
+ * @param ms - Time in milliseconds
+ * @returns Formatted time string (e.g., "05:30" or "1:23:45")
+ *
+ * @example
+ * ```typescript
+ * formatTimestamp(90000);  // "01:30"
+ * formatTimestamp(3725000); // "1:02:05"
+ * ```
+ */
+export function formatTimestamp(ms: number): string {
+  if (ms < 0) {
+    return '00:00';
+  }
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const pad = (n: number): string => n.toString().padStart(2, '0');
+
+  if (hours > 0) {
+    return `${hours}:${pad(minutes)}:${pad(seconds)}`;
+  }
+
+  return `${pad(minutes)}:${pad(seconds)}`;
+}
+
+/**
+ * Result of text highlighting operation
+ */
+export interface HighlightResult {
+  /** Array of text parts with match indicators */
+  readonly parts: readonly HighlightPart[];
+  /** Whether any matches were found */
+  readonly hasMatches: boolean;
+}
+
+/**
+ * A part of highlighted text
+ */
+export interface HighlightPart {
+  /** The text content */
+  readonly text: string;
+  /** Whether this part is a match */
+  readonly isMatch: boolean;
+}
+
+/**
+ * Parse text and identify search query matches for highlighting
+ *
+ * @param text - The original text to search within
+ * @param query - The search query to highlight
+ * @returns HighlightResult with parts array and match status
+ *
+ * @example
+ * ```typescript
+ * const result = parseHighlightText("This is a meeting note", "meeting");
+ * // result.parts = [
+ * //   { text: "This is a ", isMatch: false },
+ * //   { text: "meeting", isMatch: true },
+ * //   { text: " note", isMatch: false }
+ * // ]
+ * ```
+ */
+export function parseHighlightText(text: string, query: string): HighlightResult {
+  if (!query || query.trim() === '') {
+    return {
+      parts: [{ text, isMatch: false }],
+      hasMatches: false,
+    };
+  }
+
+  const trimmedQuery = query.trim();
+  // Escape special regex characters
+  const escapedQuery = trimmedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`(${escapedQuery})`, 'gi');
+  const rawParts = text.split(regex);
+
+  if (rawParts.length === 1) {
+    return {
+      parts: [{ text, isMatch: false }],
+      hasMatches: false,
+    };
+  }
+
+  const parts: HighlightPart[] = rawParts
+    .filter((part) => part !== '')
+    .map((part) => ({
+      text: part,
+      isMatch: part.toLowerCase() === trimmedQuery.toLowerCase(),
+    }));
+
+  return {
+    parts,
+    hasMatches: true,
+  };
+}
+
+/**
+ * Highlight search text within a string by wrapping matches in a mark element
+ *
+ * @param text - The original text to search within
+ * @param query - The search query to highlight
+ * @returns ReactNode with highlighted matches, or the original text if no query
+ *
+ * @example
+ * ```tsx
+ * // Returns React elements with "meeting" wrapped in <mark>
+ * highlightSearchText("This is a meeting note", "meeting");
+ * ```
+ */
+export function highlightSearchText(text: string, query: string): ReactNode {
+  const { parts, hasMatches } = parseHighlightText(text, query);
+
+  if (!hasMatches) {
+    return text;
+  }
+
+  return createElement(
+    'span',
+    null,
+    ...parts.map((part, index) => {
+      if (part.isMatch) {
+        return createElement(
+          'mark',
+          {
+            key: index,
+            className: 'bg-yellow-200 dark:bg-yellow-800 rounded px-0.5',
+          },
+          part.text
+        );
+      }
+      return part.text;
+    })
+  );
+}
+
+/**
+ * Filter transcript segments based on the provided filter conditions
+ *
+ * @param segments - Array of transcript segments to filter
+ * @param filters - Filter conditions to apply
+ * @returns Filtered array of transcript segments
+ *
+ * @example
+ * ```typescript
+ * const filtered = filterSegments(segments, {
+ *   searchQuery: "agenda",
+ *   speakerId: "user-123",
+ *   startTime: 60000,  // 1 minute
+ *   endTime: 300000,   // 5 minutes
+ * });
+ * ```
+ */
+export function filterSegments(
+  segments: readonly TranscriptSegment[],
+  filters: TranscriptFilters
+): TranscriptSegment[] {
+  const { searchQuery, speakerId, startTime, endTime } = filters;
+
+  return segments.filter((segment) => {
+    // Filter by speaker ID
+    if (speakerId !== undefined && segment.speaker.id !== speakerId) {
+      return false;
+    }
+
+    // Filter by start time (segment must start at or after the filter start time)
+    if (startTime !== undefined && segment.startTime < startTime) {
+      return false;
+    }
+
+    // Filter by end time (segment must end at or before the filter end time)
+    if (endTime !== undefined && segment.endTime > endTime) {
+      return false;
+    }
+
+    // Filter by search query (case-insensitive)
+    if (searchQuery !== undefined && searchQuery.trim() !== '') {
+      const lowerQuery = searchQuery.toLowerCase().trim();
+      const lowerText = segment.text.toLowerCase();
+      if (!lowerText.includes(lowerQuery)) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+}
+
+// ============================================================================
+// Factory Functions
+// ============================================================================
+
+/**
+ * Create default transcript filters
+ *
+ * @returns Empty filter object
+ */
+export function createDefaultTranscriptFilters(): TranscriptFilters {
+  return {};
+}
+
+/**
+ * Create empty search result
+ *
+ * @returns Empty search result object
+ */
+export function createEmptySearchResult(): TranscriptSearchResult {
+  return {
+    query: '',
+    totalMatches: 0,
+    matches: [],
+    currentMatchIndex: -1,
+  };
+}
+
+/**
+ * Create a new speaker object
+ *
+ * @param id - Speaker ID
+ * @param name - Speaker name
+ * @param avatarUrl - Optional avatar URL
+ * @returns Speaker object
+ */
+export function createSpeaker(
+  id: string,
+  name: string,
+  avatarUrl?: string
+): Speaker {
+  const speaker: Speaker = {
+    id,
+    name,
+  };
+
+  if (avatarUrl !== undefined) {
+    return { ...speaker, avatarUrl };
+  }
+
+  return speaker;
+}
+
+/**
+ * Get unique speakers from transcript segments
+ *
+ * @param segments - Array of transcript segments
+ * @returns Array of unique speakers
+ */
+export function getUniqueSpeakers(
+  segments: readonly TranscriptSegment[]
+): Speaker[] {
+  const speakerMap = new Map<string, Speaker>();
+
+  for (const segment of segments) {
+    if (!speakerMap.has(segment.speaker.id)) {
+      speakerMap.set(segment.speaker.id, segment.speaker);
+    }
+  }
+
+  return Array.from(speakerMap.values());
+}
+
+/**
+ * Calculate the duration of a transcript segment in milliseconds
+ *
+ * @param segment - Transcript segment
+ * @returns Duration in milliseconds
+ */
+export function getSegmentDuration(segment: TranscriptSegment): number {
+  return segment.endTime - segment.startTime;
+}

--- a/tests/types/transcript.test.ts
+++ b/tests/types/transcript.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Unit tests for transcript type definitions and utility functions
+ * @module tests/types/transcript
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  formatTimestamp,
+  filterSegments,
+  createDefaultTranscriptFilters,
+  createEmptySearchResult,
+  createSpeaker,
+  getUniqueSpeakers,
+  getSegmentDuration,
+  parseHighlightText,
+  highlightSearchText,
+  type Speaker,
+  type TranscriptSegment,
+  type TranscriptFilters,
+} from '@/types/transcript';
+
+// ============================================================================
+// Test Data Fixtures
+// ============================================================================
+
+const createTestSpeaker = (id: string, name: string): Speaker => ({
+  id,
+  name,
+});
+
+const createTestSegment = (
+  id: string,
+  speaker: Speaker,
+  startTime: number,
+  endTime: number,
+  text: string,
+  confidence = 0.95
+): TranscriptSegment => ({
+  id,
+  startTime,
+  endTime,
+  speaker,
+  text,
+  confidence,
+});
+
+const speaker1 = createTestSpeaker('speaker-1', 'Alice');
+const speaker2 = createTestSpeaker('speaker-2', 'Bob');
+const speaker3: Speaker = {
+  id: 'speaker-3',
+  name: 'Charlie',
+  avatarUrl: 'https://example.com/avatar.png',
+};
+
+const testSegments: TranscriptSegment[] = [
+  createTestSegment(
+    'seg-1',
+    speaker1,
+    0,
+    5000,
+    'Hello everyone, welcome to the meeting.'
+  ),
+  createTestSegment(
+    'seg-2',
+    speaker2,
+    5000,
+    10000,
+    'Thank you Alice. Let us discuss the agenda.'
+  ),
+  createTestSegment(
+    'seg-3',
+    speaker1,
+    10000,
+    20000,
+    'The first item on the agenda is the quarterly report.'
+  ),
+  createTestSegment(
+    'seg-4',
+    speaker3,
+    20000,
+    30000,
+    'I have prepared the financial summary for everyone.'
+  ),
+  createTestSegment(
+    'seg-5',
+    speaker2,
+    30000,
+    40000,
+    'Great work Charlie. The meeting is progressing well.'
+  ),
+];
+
+// ============================================================================
+// formatTimestamp Tests
+// ============================================================================
+
+describe('formatTimestamp', () => {
+  it('should format zero milliseconds as 00:00', () => {
+    expect(formatTimestamp(0)).toBe('00:00');
+  });
+
+  it('should format seconds correctly', () => {
+    expect(formatTimestamp(5000)).toBe('00:05');
+    expect(formatTimestamp(30000)).toBe('00:30');
+    expect(formatTimestamp(59000)).toBe('00:59');
+  });
+
+  it('should format minutes and seconds correctly', () => {
+    expect(formatTimestamp(60000)).toBe('01:00');
+    expect(formatTimestamp(90000)).toBe('01:30');
+    expect(formatTimestamp(600000)).toBe('10:00');
+    expect(formatTimestamp(3599000)).toBe('59:59');
+  });
+
+  it('should format hours, minutes, and seconds correctly', () => {
+    expect(formatTimestamp(3600000)).toBe('1:00:00');
+    expect(formatTimestamp(3725000)).toBe('1:02:05');
+    expect(formatTimestamp(7200000)).toBe('2:00:00');
+    expect(formatTimestamp(36000000)).toBe('10:00:00');
+  });
+
+  it('should handle negative values by returning 00:00', () => {
+    expect(formatTimestamp(-1000)).toBe('00:00');
+    expect(formatTimestamp(-100000)).toBe('00:00');
+  });
+
+  it('should handle fractional milliseconds by rounding down', () => {
+    expect(formatTimestamp(1500)).toBe('00:01');
+    expect(formatTimestamp(1999)).toBe('00:01');
+    expect(formatTimestamp(2000)).toBe('00:02');
+  });
+});
+
+// ============================================================================
+// filterSegments Tests
+// ============================================================================
+
+describe('filterSegments', () => {
+  it('should return all segments with empty filters', () => {
+    const result = filterSegments(testSegments, {});
+    expect(result).toHaveLength(5);
+  });
+
+  it('should filter by speaker ID', () => {
+    const result = filterSegments(testSegments, { speakerId: 'speaker-1' });
+    expect(result).toHaveLength(2);
+    expect(result.every((s) => s.speaker.id === 'speaker-1')).toBe(true);
+  });
+
+  it('should filter by start time', () => {
+    const result = filterSegments(testSegments, { startTime: 20000 });
+    expect(result).toHaveLength(2);
+    expect(result.every((s) => s.startTime >= 20000)).toBe(true);
+  });
+
+  it('should filter by end time', () => {
+    const result = filterSegments(testSegments, { endTime: 15000 });
+    expect(result).toHaveLength(2);
+    expect(result.every((s) => s.endTime <= 15000)).toBe(true);
+  });
+
+  it('should filter by search query (case-insensitive)', () => {
+    const result = filterSegments(testSegments, { searchQuery: 'agenda' });
+    expect(result).toHaveLength(2);
+    expect(
+      result.every((s) => s.text.toLowerCase().includes('agenda'))
+    ).toBe(true);
+  });
+
+  it('should handle search query with mixed case', () => {
+    const result = filterSegments(testSegments, { searchQuery: 'MEETING' });
+    expect(result).toHaveLength(2);
+  });
+
+  it('should combine multiple filters', () => {
+    const result = filterSegments(testSegments, {
+      speakerId: 'speaker-2',
+      startTime: 0,
+      endTime: 15000,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('seg-2');
+  });
+
+  it('should return empty array when no segments match', () => {
+    const result = filterSegments(testSegments, {
+      searchQuery: 'nonexistent text',
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it('should ignore empty search query', () => {
+    const result = filterSegments(testSegments, { searchQuery: '   ' });
+    expect(result).toHaveLength(5);
+  });
+
+  it('should filter with all conditions combined', () => {
+    const result = filterSegments(testSegments, {
+      searchQuery: 'agenda',
+      speakerId: 'speaker-1',
+      startTime: 0,
+      endTime: 25000,
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('seg-3');
+  });
+});
+
+// ============================================================================
+// createDefaultTranscriptFilters Tests
+// ============================================================================
+
+describe('createDefaultTranscriptFilters', () => {
+  it('should return an empty filter object', () => {
+    const filters = createDefaultTranscriptFilters();
+    expect(filters).toEqual({});
+  });
+
+  it('should be usable with filterSegments', () => {
+    const filters = createDefaultTranscriptFilters();
+    const result = filterSegments(testSegments, filters);
+    expect(result).toHaveLength(5);
+  });
+});
+
+// ============================================================================
+// createEmptySearchResult Tests
+// ============================================================================
+
+describe('createEmptySearchResult', () => {
+  it('should return an empty search result object', () => {
+    const result = createEmptySearchResult();
+    expect(result).toEqual({
+      query: '',
+      totalMatches: 0,
+      matches: [],
+      currentMatchIndex: -1,
+    });
+  });
+});
+
+// ============================================================================
+// createSpeaker Tests
+// ============================================================================
+
+describe('createSpeaker', () => {
+  it('should create a speaker without avatar URL', () => {
+    const speaker = createSpeaker('user-1', 'John Doe');
+    expect(speaker).toEqual({
+      id: 'user-1',
+      name: 'John Doe',
+    });
+    expect(speaker.avatarUrl).toBeUndefined();
+  });
+
+  it('should create a speaker with avatar URL', () => {
+    const speaker = createSpeaker(
+      'user-2',
+      'Jane Doe',
+      'https://example.com/avatar.jpg'
+    );
+    expect(speaker).toEqual({
+      id: 'user-2',
+      name: 'Jane Doe',
+      avatarUrl: 'https://example.com/avatar.jpg',
+    });
+  });
+});
+
+// ============================================================================
+// getUniqueSpeakers Tests
+// ============================================================================
+
+describe('getUniqueSpeakers', () => {
+  it('should return unique speakers from segments', () => {
+    const speakers = getUniqueSpeakers(testSegments);
+    expect(speakers).toHaveLength(3);
+    expect(speakers.map((s) => s.id).sort()).toEqual([
+      'speaker-1',
+      'speaker-2',
+      'speaker-3',
+    ]);
+  });
+
+  it('should return empty array for empty segments', () => {
+    const speakers = getUniqueSpeakers([]);
+    expect(speakers).toHaveLength(0);
+  });
+
+  it('should preserve speaker data', () => {
+    const speakers = getUniqueSpeakers(testSegments);
+    const charlie = speakers.find((s) => s.id === 'speaker-3');
+    expect(charlie).toBeDefined();
+    expect(charlie?.avatarUrl).toBe('https://example.com/avatar.png');
+  });
+
+  it('should return speakers in order of first appearance', () => {
+    const speakers = getUniqueSpeakers(testSegments);
+    expect(speakers[0]?.id).toBe('speaker-1');
+    expect(speakers[1]?.id).toBe('speaker-2');
+    expect(speakers[2]?.id).toBe('speaker-3');
+  });
+});
+
+// ============================================================================
+// getSegmentDuration Tests
+// ============================================================================
+
+describe('getSegmentDuration', () => {
+  it('should calculate segment duration correctly', () => {
+    const segment = testSegments[0];
+    expect(segment).toBeDefined();
+    expect(getSegmentDuration(segment!)).toBe(5000);
+  });
+
+  it('should handle various durations', () => {
+    expect(getSegmentDuration(testSegments[2]!)).toBe(10000);
+    expect(getSegmentDuration(testSegments[3]!)).toBe(10000);
+  });
+
+  it('should return 0 for segments with same start and end time', () => {
+    const zeroSegment = createTestSegment(
+      'zero',
+      speaker1,
+      5000,
+      5000,
+      'Instant'
+    );
+    expect(getSegmentDuration(zeroSegment)).toBe(0);
+  });
+});
+
+// ============================================================================
+// parseHighlightText Tests
+// ============================================================================
+
+describe('parseHighlightText', () => {
+  it('should return no matches for empty query', () => {
+    const result = parseHighlightText('Hello world', '');
+    expect(result.hasMatches).toBe(false);
+    expect(result.parts).toHaveLength(1);
+    expect(result.parts[0]).toEqual({ text: 'Hello world', isMatch: false });
+  });
+
+  it('should return no matches for whitespace-only query', () => {
+    const result = parseHighlightText('Hello world', '   ');
+    expect(result.hasMatches).toBe(false);
+  });
+
+  it('should find and mark single match', () => {
+    const result = parseHighlightText('Hello world', 'world');
+    expect(result.hasMatches).toBe(true);
+    expect(result.parts).toHaveLength(2);
+    expect(result.parts[0]).toEqual({ text: 'Hello ', isMatch: false });
+    expect(result.parts[1]).toEqual({ text: 'world', isMatch: true });
+  });
+
+  it('should find multiple matches', () => {
+    const result = parseHighlightText('hello hello hello', 'hello');
+    expect(result.hasMatches).toBe(true);
+    expect(result.parts.filter((p) => p.isMatch)).toHaveLength(3);
+  });
+
+  it('should be case-insensitive', () => {
+    const result = parseHighlightText('Hello HELLO hello', 'hello');
+    expect(result.hasMatches).toBe(true);
+    expect(result.parts.filter((p) => p.isMatch)).toHaveLength(3);
+  });
+
+  it('should preserve original case in output', () => {
+    const result = parseHighlightText('Hello World WORLD', 'world');
+    expect(result.hasMatches).toBe(true);
+    const matches = result.parts.filter((p) => p.isMatch);
+    expect(matches[0]?.text).toBe('World');
+    expect(matches[1]?.text).toBe('WORLD');
+  });
+
+  it('should handle special regex characters in query', () => {
+    const result = parseHighlightText('Price: $100.00', '$100.00');
+    expect(result.hasMatches).toBe(true);
+    expect(result.parts.find((p) => p.isMatch)?.text).toBe('$100.00');
+  });
+
+  it('should return no matches when query not found', () => {
+    const result = parseHighlightText('Hello world', 'xyz');
+    expect(result.hasMatches).toBe(false);
+    expect(result.parts).toHaveLength(1);
+  });
+
+  it('should handle match at the beginning', () => {
+    const result = parseHighlightText('Hello world', 'Hello');
+    expect(result.hasMatches).toBe(true);
+    expect(result.parts[0]).toEqual({ text: 'Hello', isMatch: true });
+    expect(result.parts[1]).toEqual({ text: ' world', isMatch: false });
+  });
+
+  it('should handle match in the middle', () => {
+    const result = parseHighlightText('Hello beautiful world', 'beautiful');
+    expect(result.hasMatches).toBe(true);
+    expect(result.parts).toHaveLength(3);
+    expect(result.parts[1]).toEqual({ text: 'beautiful', isMatch: true });
+  });
+});
+
+// ============================================================================
+// highlightSearchText Tests
+// ============================================================================
+
+describe('highlightSearchText', () => {
+  it('should return original text for empty query', () => {
+    const result = highlightSearchText('Hello world', '');
+    expect(result).toBe('Hello world');
+  });
+
+  it('should return original text when no match found', () => {
+    const result = highlightSearchText('Hello world', 'xyz');
+    expect(result).toBe('Hello world');
+  });
+
+  it('should return ReactNode for matches', () => {
+    const result = highlightSearchText('Hello world', 'world');
+    // Result should be a React element (object), not a string
+    expect(typeof result).toBe('object');
+    expect(result).not.toBeNull();
+  });
+
+  it('should handle case-insensitive matching', () => {
+    const result = highlightSearchText('Hello WORLD', 'world');
+    expect(typeof result).toBe('object');
+  });
+});
+
+// ============================================================================
+// Type Safety Tests
+// ============================================================================
+
+describe('Type Safety', () => {
+  it('should enforce readonly on TranscriptSegment properties', () => {
+    const segment: TranscriptSegment = testSegments[0]!;
+    // These should not compile if uncommented:
+    // segment.id = 'new-id';
+    // segment.text = 'modified text';
+    expect(segment.id).toBe('seg-1');
+  });
+
+  it('should enforce readonly on Speaker properties', () => {
+    const speaker: Speaker = speaker1;
+    // These should not compile if uncommented:
+    // speaker.id = 'new-id';
+    // speaker.name = 'New Name';
+    expect(speaker.id).toBe('speaker-1');
+  });
+
+  it('should accept readonly arrays in filterSegments', () => {
+    const readonlySegments: readonly TranscriptSegment[] = testSegments;
+    const result = filterSegments(readonlySegments, {});
+    expect(result).toHaveLength(5);
+  });
+
+  it('should have correct filter types', () => {
+    const filters: TranscriptFilters = {
+      searchQuery: 'test',
+      speakerId: 'speaker-1',
+      startTime: 0,
+      endTime: 10000,
+    };
+    expect(filters.searchQuery).toBe('test');
+  });
+});


### PR DESCRIPTION
## Summary
- Lark Transcript APIとの統合を実装（TranscriptClient）
- データ変換レイヤーを追加（TranscriptService）
- 文字起こし表示UIコンポーネントを追加（TranscriptViewer, SpeakerSegment, TranscriptSearch, TranscriptSkeleton）
- 会議詳細ページに文字起こしセクションを統合（TranscriptSection）

## Changes
| File | Description |
|------|-------------|
| `src/lib/lark/transcript.ts` | TranscriptClient - Lark API呼び出し |
| `src/services/transcript.service.ts` | TranscriptService - データ変換レイヤー |
| `src/app/api/meetings/[id]/transcript/route.ts` | API Route |
| `src/components/transcript/TranscriptViewer.tsx` | メインビューア（検索、展開/折りたたみ、無限スクロール） |
| `src/components/transcript/SpeakerSegment.tsx` | 話者セグメント（タイムスタンプ、アバター） |
| `src/components/transcript/TranscriptSearch.tsx` | 検索ナビゲーション |
| `src/components/transcript/TranscriptSkeleton.tsx` | ローディング状態 |
| `src/app/(dashboard)/meetings/[id]/_components/transcript-section.tsx` | ページ統合 |

## Quality
- ReviewAgent: 92/100点でPASS
- TypeScript/ESLint: 0エラー
- バックエンドテストカバレッジ: 90%+

## Test plan
- [ ] TranscriptClientテスト（31テスト）
- [ ] TranscriptServiceテスト（29テスト）
- [ ] データモデルテスト（46テスト）
- [ ] 会議詳細ページで文字起こし表示を確認

Closes #5

---

🤖 Generated with [Claude Code](https://claude.com/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>