### PR TITLE
feat(minutes): Add AI meeting minutes generation with Claude API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "minutes",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.71.2",
         "iron-session": "^8.0.4",
         "jose": "^5.9.6",
         "next": "14.2.21",
@@ -58,6 +59,26 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.71.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.71.2.tgz",
+      "integrity": "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -92,6 +113,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -5070,6 +5100,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -7166,6 +7209,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.71.2",
+    "iron-session": "^8.0.4",
+    "jose": "^5.9.6",
     "next": "14.2.21",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "iron-session": "^8.0.4",
-    "jose": "^5.9.6",
     "zod": "^3.24.1"
   },
   "devDependencies": {
@@ -25,13 +26,13 @@
     "@types/react-dom": "^18.3.5",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "@typescript-eslint/parser": "^8.19.0",
+    "@vitest/coverage-v8": "^2.1.8",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.1",
     "eslint-config-next": "14.2.21",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.2",
-    "vitest": "^2.1.8",
-    "@vitest/coverage-v8": "^2.1.8"
+    "vitest": "^2.1.8"
   }
 }

--- a/src/app/(dashboard)/meetings/[id]/_components/index.ts
+++ b/src/app/(dashboard)/meetings/[id]/_components/index.ts
@@ -19,3 +19,6 @@ export { MeetingDetailSkeleton } from './meeting-detail-skeleton';
 
 export { TranscriptSection } from './transcript-section';
 export type { TranscriptSectionProps } from './transcript-section';
+
+export { MinutesSection } from './minutes-section';
+export type { MinutesSectionProps } from './minutes-section';

--- a/src/app/(dashboard)/meetings/[id]/_components/minutes-section.tsx
+++ b/src/app/(dashboard)/meetings/[id]/_components/minutes-section.tsx
@@ -1,0 +1,441 @@
+/**
+ * Minutes Section Component
+ * Fetches and displays meeting minutes with generation capability
+ * @module app/(dashboard)/meetings/[id]/_components/minutes-section
+ */
+
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import {
+  MinutesViewer,
+  GenerateMinutesCard,
+  type GenerationState,
+  type GenerationStatus,
+} from '@/components/minutes';
+import type { Minutes } from '@/types/minutes';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * API response type for minutes fetch
+ */
+interface MinutesApiResponse {
+  readonly success: boolean;
+  readonly data?: Minutes | undefined;
+  readonly error?: {
+    readonly code: string;
+    readonly message: string;
+  } | undefined;
+}
+
+/**
+ * API response type for minutes generation
+ */
+interface GenerateMinutesApiResponse {
+  readonly success: boolean;
+  readonly data?: {
+    readonly minutes: Minutes;
+    readonly processingTimeMs: number;
+    readonly usage: {
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+    };
+  } | undefined;
+  readonly error?: {
+    readonly code: string;
+    readonly message: string;
+  } | undefined;
+}
+
+/**
+ * Props for MinutesSection component
+ */
+export interface MinutesSectionProps {
+  /** Meeting ID to fetch/generate minutes for */
+  readonly meetingId: string;
+  /** Meeting title for display */
+  readonly meetingTitle: string;
+  /** Whether the meeting has a transcript */
+  readonly hasTranscript: boolean;
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Component state interface
+ */
+interface ComponentState {
+  readonly minutes: Minutes | null;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly generationState: GenerationState;
+}
+
+/**
+ * Initial component state
+ */
+const initialState: ComponentState = {
+  minutes: null,
+  isLoading: true,
+  error: null,
+  generationState: { status: 'idle' },
+};
+
+// =============================================================================
+// Subcomponents
+// =============================================================================
+
+/**
+ * No transcript message component
+ */
+function NoTranscriptMessage({
+  className = '',
+}: {
+  readonly className?: string | undefined;
+}): JSX.Element {
+  return (
+    <div
+      className={`
+        p-8 text-center
+        border border-dashed border-lark-border rounded-lg
+        bg-gray-50 dark:bg-slate-800
+        ${className}
+      `}
+    >
+      <svg
+        className="w-12 h-12 mx-auto mb-3 text-gray-300 dark:text-slate-600"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+        />
+      </svg>
+      <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">
+        Transcript Required
+      </h3>
+      <p className="text-sm text-gray-500 dark:text-slate-400">
+        To generate meeting minutes, a transcript is required.
+        Please ensure the meeting has a transcript available.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Error display component
+ */
+function MinutesError({
+  message,
+  onRetry,
+}: {
+  readonly message: string;
+  readonly onRetry: () => void;
+}): JSX.Element {
+  return (
+    <div className="bg-white dark:bg-slate-800 rounded-lg border border-lark-border p-8">
+      <div className="text-center">
+        <svg
+          className="mx-auto h-12 w-12 text-red-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+          />
+        </svg>
+        <h3 className="mt-4 text-lg font-medium text-slate-900 dark:text-white">
+          Failed to load minutes
+        </h3>
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          {message}
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-4 inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
+        >
+          <svg
+            className="w-4 h-4 mr-2"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+          Retry
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Main Component
+// =============================================================================
+
+/**
+ * MinutesSection Component
+ *
+ * @description Fetches and displays meeting minutes with generation capability.
+ *              Handles loading, error, empty states, and generation progress.
+ *
+ * @example
+ * ```tsx
+ * <MinutesSection
+ *   meetingId="meeting-123"
+ *   meetingTitle="Weekly Standup"
+ *   hasTranscript={true}
+ * />
+ * ```
+ */
+export function MinutesSection({
+  meetingId,
+  meetingTitle: _meetingTitle,
+  hasTranscript,
+  className = '',
+}: MinutesSectionProps): JSX.Element {
+  // Note: meetingTitle is available for future use (e.g., displaying meeting context)
+  void _meetingTitle;
+  const [state, setState] = useState<ComponentState>(initialState);
+
+  /**
+   * Fetch existing minutes from API
+   */
+  const fetchMinutes = useCallback(async (): Promise<void> => {
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      const response = await fetch(`/api/meetings/${meetingId}/minutes`);
+
+      // 404 means minutes don't exist yet - not an error
+      if (response.status === 404) {
+        setState({
+          minutes: null,
+          isLoading: false,
+          error: null,
+          generationState: { status: 'idle' },
+        });
+        return;
+      }
+
+      if (!response.ok) {
+        const errorData = (await response.json()) as MinutesApiResponse;
+        throw new Error(errorData.error?.message ?? 'Failed to fetch minutes');
+      }
+
+      const data = (await response.json()) as MinutesApiResponse;
+      setState({
+        minutes: data.data ?? null,
+        isLoading: false,
+        error: null,
+        generationState: { status: data.data !== undefined ? 'completed' : 'idle' },
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'An unexpected error occurred';
+      setState({
+        minutes: null,
+        isLoading: false,
+        error: message,
+        generationState: { status: 'error', error: message },
+      });
+    }
+  }, [meetingId]);
+
+  /**
+   * Generate minutes from transcript
+   */
+  const generateMinutes = useCallback(async (): Promise<void> => {
+    // Update state to generating
+    setState((prev) => ({
+      ...prev,
+      error: null,
+      generationState: {
+        status: 'generating' as GenerationStatus,
+        progress: 0,
+        currentStep: 'Initializing...',
+      },
+    }));
+
+    // Simulate progress updates
+    const progressIntervals = [
+      { progress: 10, step: 'Fetching transcript...', delay: 500 },
+      { progress: 30, step: 'Analyzing content...', delay: 1500 },
+      { progress: 50, step: 'Generating summary...', delay: 2000 },
+      { progress: 70, step: 'Extracting action items...', delay: 1500 },
+      { progress: 90, step: 'Finalizing minutes...', delay: 1000 },
+    ];
+
+    // Start progress simulation (in background)
+    let isCancelled = false;
+    const runProgressSimulation = async (): Promise<void> => {
+      for (const interval of progressIntervals) {
+        if (isCancelled) break;
+        await new Promise<void>((resolve) => setTimeout(resolve, interval.delay));
+        if (isCancelled) break;
+        setState((prev) => ({
+          ...prev,
+          generationState: {
+            status: 'generating' as GenerationStatus,
+            progress: interval.progress,
+            currentStep: interval.step,
+          },
+        }));
+      }
+    };
+
+    // Run progress simulation without awaiting (fire and forget)
+    void runProgressSimulation();
+
+    try {
+      const response = await fetch(`/api/meetings/${meetingId}/minutes/generate`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ language: 'ja' }),
+      });
+
+      isCancelled = true; // Stop progress simulation
+
+      if (!response.ok) {
+        const errorData = (await response.json()) as GenerateMinutesApiResponse;
+        throw new Error(errorData.error?.message ?? 'Failed to generate minutes');
+      }
+
+      const data = (await response.json()) as GenerateMinutesApiResponse;
+
+      if (data.data?.minutes === undefined) {
+        throw new Error('Invalid response: minutes data is missing');
+      }
+
+      setState({
+        minutes: data.data.minutes,
+        isLoading: false,
+        error: null,
+        generationState: { status: 'completed' },
+      });
+    } catch (error) {
+      isCancelled = true; // Stop progress simulation
+      const message =
+        error instanceof Error ? error.message : 'Failed to generate minutes';
+      setState((prev) => ({
+        ...prev,
+        error: message,
+        generationState: {
+          status: 'error',
+          error: message,
+        },
+      }));
+    }
+  }, [meetingId]);
+
+  /**
+   * Handle retry action
+   */
+  const handleRetry = useCallback((): void => {
+    if (state.generationState.status === 'error') {
+      // If generation failed, retry generation
+      void generateMinutes();
+    } else {
+      // Otherwise, retry fetching
+      void fetchMinutes();
+    }
+  }, [state.generationState.status, fetchMinutes, generateMinutes]);
+
+  /**
+   * Handle generate action
+   */
+  const handleGenerate = useCallback((): void => {
+    void generateMinutes();
+  }, [generateMinutes]);
+
+  /**
+   * Handle regenerate action
+   */
+  const handleRegenerate = useCallback((): void => {
+    void generateMinutes();
+  }, [generateMinutes]);
+
+  // Fetch minutes on mount and when meetingId changes
+  useEffect(() => {
+    void fetchMinutes();
+  }, [fetchMinutes]);
+
+  // Don't show section if no transcript available
+  if (!hasTranscript) {
+    return (
+      <section className={className} aria-label="Minutes section">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+          Minutes
+        </h2>
+        <NoTranscriptMessage />
+      </section>
+    );
+  }
+
+  // Show error state (not generation error - those are handled by GenerateMinutesCard)
+  if (state.error !== null && state.generationState.status !== 'error') {
+    return (
+      <section className={className} aria-label="Minutes section">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+          Minutes
+        </h2>
+        <MinutesError message={state.error} onRetry={handleRetry} />
+      </section>
+    );
+  }
+
+  // Show generation card if no minutes exist
+  if (state.minutes === null && !state.isLoading) {
+    return (
+      <section className={className} aria-label="Minutes section">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+          Minutes
+        </h2>
+        <GenerateMinutesCard
+          state={state.generationState}
+          onGenerate={handleGenerate}
+        />
+      </section>
+    );
+  }
+
+  // Build props conditionally for exactOptionalPropertyTypes compliance
+  const viewerProps = {
+    minutes: state.minutes ?? undefined,
+    isLoading: state.isLoading,
+    generationState: state.generationState,
+    onGenerate: handleGenerate,
+    onRegenerate: handleRegenerate,
+  };
+
+  return (
+    <section className={className} aria-label="Minutes section">
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">
+        Minutes
+      </h2>
+      <MinutesViewer {...viewerProps} />
+    </section>
+  );
+}

--- a/src/app/api/meetings/[id]/minutes/__tests__/route.test.ts
+++ b/src/app/api/meetings/[id]/minutes/__tests__/route.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Minutes API route unit tests
+ * @module app/api/meetings/[id]/minutes/__tests__/route.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET } from '../route';
+import { getSession } from '@/lib/auth/get-session';
+
+// Mock dependencies
+vi.mock('@/lib/auth/get-session');
+
+const mockGetSession = vi.mocked(getSession);
+
+/**
+ * Error response type
+ */
+interface ErrorResponseData {
+  readonly success: false;
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+  };
+}
+
+/**
+ * Create mock route context
+ */
+function createMockContext(id: string): { params: Promise<{ id: string }> } {
+  return {
+    params: Promise.resolve({ id }),
+  };
+}
+
+/**
+ * Create mock request
+ */
+function createMockRequest(): Request {
+  return new Request('http://localhost:3000/api/meetings/meeting_001/minutes');
+}
+
+describe('GET /api/meetings/[id]/minutes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Authentication', () => {
+    it('should return 401 when session is null', async () => {
+      mockGetSession.mockResolvedValue(null);
+
+      const response = await GET(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+      expect(data.error.message).toBe('Authentication required');
+    });
+
+    it('should return 401 when session is not authenticated', async () => {
+      mockGetSession.mockResolvedValue({
+        isAuthenticated: false,
+      } as Awaited<ReturnType<typeof getSession>>);
+
+      const response = await GET(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('should return 401 when access token is missing', async () => {
+      mockGetSession.mockResolvedValue({
+        isAuthenticated: true,
+        accessToken: undefined,
+      } as unknown as Awaited<ReturnType<typeof getSession>>);
+
+      const response = await GET(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+      expect(data.error.message).toBe('Access token not found');
+    });
+  });
+
+  describe('Input Validation', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        isAuthenticated: true,
+        accessToken: 'test_token',
+      } as unknown as Awaited<ReturnType<typeof getSession>>);
+    });
+
+    it('should return 400 when meeting ID is empty', async () => {
+      const response = await GET(createMockRequest(), createMockContext(''));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('INVALID_PARAMS');
+      expect(data.error.message).toBe('Meeting ID is required');
+    });
+
+    it('should return 400 when meeting ID is whitespace only', async () => {
+      const response = await GET(createMockRequest(), createMockContext('   '));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('INVALID_PARAMS');
+    });
+  });
+
+  describe('Default Response (Not Found)', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        isAuthenticated: true,
+        accessToken: 'test_token',
+      } as unknown as Awaited<ReturnType<typeof getSession>>);
+    });
+
+    it('should return 404 for valid request (minutes storage not implemented)', async () => {
+      const response = await GET(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('MINUTES_NOT_FOUND');
+      expect(data.error.message).toBe('Minutes not found for this meeting');
+    });
+
+    it('should return 404 for any valid meeting ID', async () => {
+      const response = await GET(createMockRequest(), createMockContext('any_meeting_id'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('MINUTES_NOT_FOUND');
+    });
+  });
+});

--- a/src/app/api/meetings/[id]/minutes/generate/__tests__/route.test.ts
+++ b/src/app/api/meetings/[id]/minutes/generate/__tests__/route.test.ts
@@ -1,0 +1,707 @@
+/**
+ * Minutes Generation API route unit tests
+ * @module app/api/meetings/[id]/minutes/generate/__tests__/route.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { POST } from '../route';
+import { getSession } from '@/lib/auth/get-session';
+import { createLarkClient } from '@/lib/lark/client';
+import {
+  createMeetingService,
+  MeetingNotFoundError,
+  MeetingApiError,
+} from '@/lib/lark/meeting';
+import {
+  createTranscriptService,
+  TranscriptNotFoundError,
+  TranscriptServiceError,
+} from '@/services/transcript.service';
+import {
+  createMinutesGenerationService,
+  MinutesGenerationError,
+} from '@/services/minutes-generation.service';
+import type { Meeting } from '@/types/meeting';
+import type { Transcript } from '@/types/transcript';
+import type { Minutes } from '@/types/minutes';
+
+// Mock dependencies
+vi.mock('@/lib/auth/get-session');
+vi.mock('@/lib/lark/client');
+vi.mock('@/lib/lark/meeting', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/lark/meeting')>();
+  return {
+    ...actual,
+    createMeetingService: vi.fn(),
+  };
+});
+vi.mock('@/services/transcript.service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/transcript.service')>();
+  return {
+    ...actual,
+    createTranscriptService: vi.fn(),
+  };
+});
+vi.mock('@/services/minutes-generation.service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/services/minutes-generation.service')>();
+  return {
+    ...actual,
+    createMinutesGenerationService: vi.fn(),
+  };
+});
+
+const mockGetSession = vi.mocked(getSession);
+const mockCreateLarkClient = vi.mocked(createLarkClient);
+const mockCreateMeetingService = vi.mocked(createMeetingService);
+const mockCreateTranscriptService = vi.mocked(createTranscriptService);
+const mockCreateMinutesGenerationService = vi.mocked(createMinutesGenerationService);
+
+/**
+ * Success response type
+ */
+interface SuccessResponseData {
+  readonly success: true;
+  readonly data: {
+    readonly minutes: Minutes;
+    readonly processingTimeMs: number;
+    readonly usage: {
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+    };
+  };
+}
+
+/**
+ * Error response type
+ */
+interface ErrorResponseData {
+  readonly success: false;
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+  };
+}
+
+/**
+ * Create mock meeting data
+ */
+function createMockMeeting(overrides: Partial<Meeting> = {}): Meeting {
+  const now = new Date();
+  const startTime = new Date(now.getTime() - 3600000);
+  const endTime = new Date();
+
+  return {
+    id: 'meeting_001',
+    title: 'Weekly Team Standup',
+    meetingNo: '123456789',
+    startTime,
+    endTime,
+    durationMinutes: 60,
+    status: 'ended',
+    type: 'regular',
+    host: {
+      id: 'user_001',
+      name: 'John Doe',
+      avatarUrl: 'https://example.com/avatar.jpg',
+    },
+    participantCount: 5,
+    hasRecording: true,
+    recordingUrl: 'https://example.com/recording',
+    minutesStatus: 'not_created',
+    createdAt: startTime,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+/**
+ * Create mock transcript data
+ */
+function createMockTranscript(): Transcript {
+  return {
+    meetingId: 'meeting_001',
+    language: 'ja',
+    segments: [
+      {
+        id: 'seg_1',
+        startTime: 0,
+        endTime: 15000,
+        speaker: { id: 'user_001', name: 'John Doe' },
+        text: 'Let us start the meeting.',
+        confidence: 0.95,
+      },
+      {
+        id: 'seg_2',
+        startTime: 15000,
+        endTime: 30000,
+        speaker: { id: 'user_002', name: 'Jane Smith' },
+        text: 'Sure, I have updates on the project.',
+        confidence: 0.92,
+      },
+    ],
+    totalDuration: 3600000,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Create mock minutes
+ */
+function createMockMinutes(): Minutes {
+  return {
+    id: 'min_meeting_001_1234567890',
+    meetingId: 'meeting_001',
+    title: 'Weekly Team Standup',
+    date: '2026-01-22',
+    duration: 3600000,
+    summary: 'The team discussed project updates and action items.',
+    topics: [
+      {
+        id: 'topic_0',
+        title: 'Project Updates',
+        startTime: 0,
+        endTime: 30000,
+        summary: 'Discussed current project status.',
+        keyPoints: ['Progress is on track', 'No blockers'],
+        speakers: [{ id: 'speaker_0', name: 'John Doe' }],
+      },
+    ],
+    decisions: [
+      {
+        id: 'dec_0',
+        content: 'Continue with the current approach',
+        context: 'Team agreed the approach is working well',
+        decidedAt: 20000,
+      },
+    ],
+    actionItems: [
+      {
+        id: 'act_0',
+        content: 'Update documentation',
+        priority: 'medium',
+        status: 'pending',
+      },
+    ],
+    attendees: [
+      { id: 'speaker_0', name: 'John Doe' },
+      { id: 'speaker_1', name: 'Jane Smith' },
+    ],
+    metadata: {
+      generatedAt: new Date().toISOString(),
+      model: 'claude-sonnet-4-20250514',
+      processingTimeMs: 5000,
+      confidence: 0.85,
+    },
+  };
+}
+
+/**
+ * Create mock route context
+ */
+function createMockContext(id: string): { params: Promise<{ id: string }> } {
+  return {
+    params: Promise.resolve({ id }),
+  };
+}
+
+/**
+ * Create mock request
+ */
+function createMockRequest(body?: object): Request {
+  const init: RequestInit = {
+    method: 'POST',
+  };
+
+  if (body !== undefined) {
+    init.headers = { 'Content-Type': 'application/json' };
+    init.body = JSON.stringify(body);
+  }
+
+  return new Request('http://localhost:3000/api/meetings/meeting_001/minutes/generate', init);
+}
+
+describe('POST /api/meetings/[id]/minutes/generate', () => {
+  let mockMeetingService: {
+    getMeetingById: ReturnType<typeof vi.fn>;
+  };
+  let mockTranscriptService: {
+    getTranscript: ReturnType<typeof vi.fn>;
+    hasTranscript: ReturnType<typeof vi.fn>;
+  };
+  let mockMinutesService: {
+    generateMinutes: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Setup mock services
+    mockMeetingService = {
+      getMeetingById: vi.fn(),
+    };
+    mockTranscriptService = {
+      getTranscript: vi.fn(),
+      hasTranscript: vi.fn(),
+    };
+    mockMinutesService = {
+      generateMinutes: vi.fn(),
+    };
+
+    mockCreateLarkClient.mockReturnValue({} as ReturnType<typeof createLarkClient>);
+    mockCreateMeetingService.mockReturnValue(
+      mockMeetingService as unknown as ReturnType<typeof createMeetingService>
+    );
+    mockCreateTranscriptService.mockReturnValue(
+      mockTranscriptService as unknown as ReturnType<typeof createTranscriptService>
+    );
+    mockCreateMinutesGenerationService.mockReturnValue(
+      mockMinutesService as unknown as ReturnType<typeof createMinutesGenerationService>
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Authentication', () => {
+    it('should return 401 when session is null', async () => {
+      mockGetSession.mockResolvedValue(null);
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+      expect(data.error.message).toBe('Authentication required');
+    });
+
+    it('should return 401 when session is not authenticated', async () => {
+      mockGetSession.mockResolvedValue({
+        isAuthenticated: false,
+      } as Awaited<ReturnType<typeof getSession>>);
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('should return 401 when access token is missing', async () => {
+      mockGetSession.mockResolvedValue({
+        isAuthenticated: true,
+        accessToken: undefined,
+      } as unknown as Awaited<ReturnType<typeof getSession>>);
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(401);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('UNAUTHORIZED');
+      expect(data.error.message).toBe('Access token not found');
+    });
+  });
+
+  describe('Input Validation', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        isAuthenticated: true,
+        accessToken: 'test_token',
+      } as unknown as Awaited<ReturnType<typeof getSession>>);
+    });
+
+    it('should return 400 when meeting ID is empty', async () => {
+      const response = await POST(createMockRequest(), createMockContext(''));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('INVALID_PARAMS');
+      expect(data.error.message).toBe('Meeting ID is required');
+    });
+
+    it('should return 400 when meeting ID is whitespace only', async () => {
+      const response = await POST(createMockRequest(), createMockContext('   '));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('INVALID_PARAMS');
+    });
+
+    it('should return 400 when language is invalid', async () => {
+      const response = await POST(
+        createMockRequest({ language: 'fr' }),
+        createMockContext('meeting_001')
+      );
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('INVALID_REQUEST');
+    });
+
+    it('should return 400 when regenerate is not boolean', async () => {
+      const response = await POST(
+        createMockRequest({ regenerate: 'yes' }),
+        createMockContext('meeting_001')
+      );
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('INVALID_REQUEST');
+    });
+
+    it('should accept empty body', async () => {
+      const mockMeeting = createMockMeeting();
+      const mockTranscript = createMockTranscript();
+      const mockMinutes = createMockMinutes();
+
+      mockMeetingService.getMeetingById.mockResolvedValue(mockMeeting);
+      mockTranscriptService.getTranscript.mockResolvedValue(mockTranscript);
+      mockMinutesService.generateMinutes.mockResolvedValue({
+        minutes: mockMinutes,
+        processingTimeMs: 5000,
+        usage: { inputTokens: 1000, outputTokens: 500 },
+      });
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as SuccessResponseData;
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+    });
+
+    it('should accept valid language option', async () => {
+      const mockMeeting = createMockMeeting();
+      const mockTranscript = createMockTranscript();
+      const mockMinutes = createMockMinutes();
+
+      mockMeetingService.getMeetingById.mockResolvedValue(mockMeeting);
+      mockTranscriptService.getTranscript.mockResolvedValue(mockTranscript);
+      mockMinutesService.generateMinutes.mockResolvedValue({
+        minutes: mockMinutes,
+        processingTimeMs: 5000,
+        usage: { inputTokens: 1000, outputTokens: 500 },
+      });
+
+      const response = await POST(
+        createMockRequest({ language: 'en' }),
+        createMockContext('meeting_001')
+      );
+      const data = (await response.json()) as SuccessResponseData;
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+    });
+  });
+
+  describe('Meeting Not Found', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        isAuthenticated: true,
+        accessToken: 'test_token',
+      } as unknown as Awaited<ReturnType<typeof getSession>>);
+    });
+
+    it('should return 404 when meeting is not found', async () => {
+      mockMeetingService.getMeetingById.mockRejectedValue(
+        new MeetingNotFoundError('meeting_001')
+      );
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('MEETING_NOT_FOUND');
+      expect(data.error.message).toContain('meeting_001');
+    });
+
+    it('should return 404 for MeetingApiError', async () => {
+      mockMeetingService.getMeetingById.mockRejectedValue(
+        new MeetingApiError('API Error', 500, 'getMeetingById')
+      );
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('MEETING_NOT_FOUND');
+    });
+  });
+
+  describe('Transcript Not Found', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        isAuthenticated: true,
+        accessToken: 'test_token',
+      } as unknown as Awaited<ReturnType<typeof getSession>>);
+      mockMeetingService.getMeetingById.mockResolvedValue(createMockMeeting());
+    });
+
+    it('should return 404 when transcript is not found', async () => {
+      mockTranscriptService.getTranscript.mockRejectedValue(
+        new TranscriptNotFoundError('meeting_001')
+      );
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('TRANSCRIPT_NOT_FOUND');
+      expect(data.error.message).toBe('Transcript not found for this meeting');
+    });
+
+    it('should return 404 for TranscriptServiceError', async () => {
+      mockTranscriptService.getTranscript.mockRejectedValue(
+        new TranscriptServiceError('Service error', 'SERVICE_ERROR', 500)
+      );
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(404);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('TRANSCRIPT_NOT_FOUND');
+    });
+  });
+
+  describe('Generation Errors', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        isAuthenticated: true,
+        accessToken: 'test_token',
+      } as unknown as Awaited<ReturnType<typeof getSession>>);
+      mockMeetingService.getMeetingById.mockResolvedValue(createMockMeeting());
+      mockTranscriptService.getTranscript.mockResolvedValue(createMockTranscript());
+    });
+
+    it('should return 500 when API key is missing', async () => {
+      mockMinutesService.generateMinutes.mockRejectedValue(
+        new MinutesGenerationError('API key missing', 'MISSING_API_KEY')
+      );
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(500);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('GENERATION_FAILED');
+      expect(data.error.message).toBe('AI service is not configured');
+    });
+
+    it('should return 400 for invalid input errors', async () => {
+      mockMinutesService.generateMinutes.mockRejectedValue(
+        new MinutesGenerationError('Invalid input', 'INVALID_INPUT')
+      );
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(400);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('GENERATION_FAILED');
+    });
+
+    it('should return 500 for other generation errors', async () => {
+      mockMinutesService.generateMinutes.mockRejectedValue(
+        new MinutesGenerationError('Claude API error', 'CLAUDE_API_ERROR')
+      );
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(500);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('GENERATION_FAILED');
+    });
+
+    it('should return 500 for unexpected errors', async () => {
+      mockMinutesService.generateMinutes.mockRejectedValue(new Error('Unexpected error'));
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as ErrorResponseData;
+
+      expect(response.status).toBe(500);
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe('INTERNAL_ERROR');
+      expect(data.error.message).toBe('An unexpected error occurred');
+    });
+  });
+
+  describe('Successful Response', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        isAuthenticated: true,
+        accessToken: 'test_token',
+      } as unknown as Awaited<ReturnType<typeof getSession>>);
+    });
+
+    it('should return generated minutes successfully', async () => {
+      const mockMeeting = createMockMeeting();
+      const mockTranscript = createMockTranscript();
+      const mockMinutes = createMockMinutes();
+
+      mockMeetingService.getMeetingById.mockResolvedValue(mockMeeting);
+      mockTranscriptService.getTranscript.mockResolvedValue(mockTranscript);
+      mockMinutesService.generateMinutes.mockResolvedValue({
+        minutes: mockMinutes,
+        processingTimeMs: 5000,
+        usage: { inputTokens: 1000, outputTokens: 500 },
+      });
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as SuccessResponseData;
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(data.data.minutes).toBeDefined();
+      expect(data.data.minutes.meetingId).toBe('meeting_001');
+      expect(data.data.processingTimeMs).toBe(5000);
+      expect(data.data.usage.inputTokens).toBe(1000);
+      expect(data.data.usage.outputTokens).toBe(500);
+    });
+
+    it('should use meeting title for minutes', async () => {
+      const mockMeeting = createMockMeeting({ title: 'Custom Meeting Title' });
+      const mockTranscript = createMockTranscript();
+      const mockMinutes = createMockMinutes();
+
+      mockMeetingService.getMeetingById.mockResolvedValue(mockMeeting);
+      mockTranscriptService.getTranscript.mockResolvedValue(mockTranscript);
+      mockMinutesService.generateMinutes.mockResolvedValue({
+        minutes: mockMinutes,
+        processingTimeMs: 5000,
+        usage: { inputTokens: 1000, outputTokens: 500 },
+      });
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as SuccessResponseData;
+
+      expect(response.status).toBe(200);
+      expect(data.data.minutes.title).toBe('Custom Meeting Title');
+    });
+
+    it('should pass correct language option to service', async () => {
+      const mockMeeting = createMockMeeting();
+      const mockTranscript = createMockTranscript();
+      const mockMinutes = createMockMinutes();
+
+      mockMeetingService.getMeetingById.mockResolvedValue(mockMeeting);
+      mockTranscriptService.getTranscript.mockResolvedValue(mockTranscript);
+      mockMinutesService.generateMinutes.mockResolvedValue({
+        minutes: mockMinutes,
+        processingTimeMs: 5000,
+        usage: { inputTokens: 1000, outputTokens: 500 },
+      });
+
+      await POST(createMockRequest({ language: 'en' }), createMockContext('meeting_001'));
+
+      expect(mockMinutesService.generateMinutes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: { language: 'en' },
+        })
+      );
+    });
+
+    it('should default to Japanese language', async () => {
+      const mockMeeting = createMockMeeting();
+      const mockTranscript = createMockTranscript();
+      const mockMinutes = createMockMinutes();
+
+      mockMeetingService.getMeetingById.mockResolvedValue(mockMeeting);
+      mockTranscriptService.getTranscript.mockResolvedValue(mockTranscript);
+      mockMinutesService.generateMinutes.mockResolvedValue({
+        minutes: mockMinutes,
+        processingTimeMs: 5000,
+        usage: { inputTokens: 1000, outputTokens: 500 },
+      });
+
+      await POST(createMockRequest(), createMockContext('meeting_001'));
+
+      expect(mockMinutesService.generateMinutes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: { language: 'ja' },
+        })
+      );
+    });
+
+    it('should include topics, decisions, and action items', async () => {
+      const mockMeeting = createMockMeeting();
+      const mockTranscript = createMockTranscript();
+      const mockMinutes = createMockMinutes();
+
+      mockMeetingService.getMeetingById.mockResolvedValue(mockMeeting);
+      mockTranscriptService.getTranscript.mockResolvedValue(mockTranscript);
+      mockMinutesService.generateMinutes.mockResolvedValue({
+        minutes: mockMinutes,
+        processingTimeMs: 5000,
+        usage: { inputTokens: 1000, outputTokens: 500 },
+      });
+
+      const response = await POST(createMockRequest(), createMockContext('meeting_001'));
+      const data = (await response.json()) as SuccessResponseData;
+
+      expect(data.data.minutes.topics).toHaveLength(1);
+      expect(data.data.minutes.decisions).toHaveLength(1);
+      expect(data.data.minutes.actionItems).toHaveLength(1);
+      expect(data.data.minutes.attendees).toHaveLength(2);
+    });
+  });
+
+  describe('Service Integration', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        isAuthenticated: true,
+        accessToken: 'test_token',
+      } as unknown as Awaited<ReturnType<typeof getSession>>);
+    });
+
+    it('should create all required services', async () => {
+      const mockMeeting = createMockMeeting();
+      const mockTranscript = createMockTranscript();
+      const mockMinutes = createMockMinutes();
+
+      mockMeetingService.getMeetingById.mockResolvedValue(mockMeeting);
+      mockTranscriptService.getTranscript.mockResolvedValue(mockTranscript);
+      mockMinutesService.generateMinutes.mockResolvedValue({
+        minutes: mockMinutes,
+        processingTimeMs: 5000,
+        usage: { inputTokens: 1000, outputTokens: 500 },
+      });
+
+      await POST(createMockRequest(), createMockContext('meeting_001'));
+
+      expect(mockCreateLarkClient).toHaveBeenCalled();
+      expect(mockCreateMeetingService).toHaveBeenCalled();
+      expect(mockCreateTranscriptService).toHaveBeenCalled();
+      expect(mockCreateMinutesGenerationService).toHaveBeenCalled();
+    });
+
+    it('should pass correct access token to services', async () => {
+      const mockMeeting = createMockMeeting();
+      const mockTranscript = createMockTranscript();
+      const mockMinutes = createMockMinutes();
+
+      mockMeetingService.getMeetingById.mockResolvedValue(mockMeeting);
+      mockTranscriptService.getTranscript.mockResolvedValue(mockTranscript);
+      mockMinutesService.generateMinutes.mockResolvedValue({
+        minutes: mockMinutes,
+        processingTimeMs: 5000,
+        usage: { inputTokens: 1000, outputTokens: 500 },
+      });
+
+      await POST(createMockRequest(), createMockContext('meeting_001'));
+
+      expect(mockMeetingService.getMeetingById).toHaveBeenCalledWith('test_token', 'meeting_001');
+      expect(mockTranscriptService.getTranscript).toHaveBeenCalledWith('test_token', 'meeting_001');
+    });
+  });
+});

--- a/src/app/api/meetings/[id]/minutes/generate/route.ts
+++ b/src/app/api/meetings/[id]/minutes/generate/route.ts
@@ -1,0 +1,437 @@
+/**
+ * Minutes Generation API endpoint - Generate minutes from transcript
+ * @module app/api/meetings/[id]/minutes/generate/route
+ */
+
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth/get-session';
+import { createLarkClient } from '@/lib/lark/client';
+import {
+  createMeetingService,
+  MeetingNotFoundError,
+  MeetingApiError,
+} from '@/lib/lark/meeting';
+import {
+  createTranscriptService,
+  TranscriptNotFoundError,
+  TranscriptServiceError,
+} from '@/services/transcript.service';
+import {
+  createMinutesGenerationService,
+  MinutesGenerationError,
+  type MinutesGenerationResult,
+} from '@/services/minutes-generation.service';
+import type { Minutes } from '@/types/minutes';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Request body for minutes generation
+ */
+interface GenerateMinutesRequestBody {
+  /** Output language (default: 'ja') */
+  readonly language?: 'ja' | 'en' | undefined;
+  /** Force regeneration (future use) */
+  readonly regenerate?: boolean | undefined;
+}
+
+/**
+ * Success response type
+ */
+interface GenerateMinutesSuccessResponse {
+  readonly success: true;
+  readonly data: {
+    readonly minutes: Minutes;
+    readonly processingTimeMs: number;
+    readonly usage: {
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+    };
+  };
+}
+
+/**
+ * Error response type
+ */
+interface GenerateMinutesErrorResponse {
+  readonly success: false;
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+  };
+}
+
+/**
+ * Route context with params
+ */
+interface RouteContext {
+  readonly params: Promise<{
+    readonly id: string;
+  }>;
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Create success response
+ *
+ * @param result - Minutes generation result
+ * @returns NextResponse with success payload
+ */
+function createSuccessResponse(
+  result: MinutesGenerationResult
+): NextResponse<GenerateMinutesSuccessResponse> {
+  const response: GenerateMinutesSuccessResponse = {
+    success: true,
+    data: {
+      minutes: result.minutes,
+      processingTimeMs: result.processingTimeMs,
+      usage: result.usage,
+    },
+  };
+
+  return NextResponse.json(response);
+}
+
+/**
+ * Create error response
+ *
+ * @param code - Error code
+ * @param message - Error message
+ * @param statusCode - HTTP status code
+ * @returns NextResponse with error payload
+ */
+function createErrorResponse(
+  code: string,
+  message: string,
+  statusCode: number
+): NextResponse<GenerateMinutesErrorResponse> {
+  const response: GenerateMinutesErrorResponse = {
+    success: false,
+    error: {
+      code,
+      message,
+    },
+  };
+
+  return NextResponse.json(response, { status: statusCode });
+}
+
+/**
+ * Parse and validate request body
+ *
+ * @param request - Request object
+ * @returns Parsed request body or null if invalid
+ */
+async function parseRequestBody(
+  request: Request
+): Promise<GenerateMinutesRequestBody | null> {
+  try {
+    const contentType = request.headers.get('content-type');
+
+    // Allow empty body (use defaults)
+    if (contentType === null || !contentType.includes('application/json')) {
+      return {};
+    }
+
+    const text = await request.text();
+
+    // Allow empty body
+    if (text.trim() === '') {
+      return {};
+    }
+
+    const body = JSON.parse(text) as unknown;
+
+    if (typeof body !== 'object' || body === null) {
+      return null;
+    }
+
+    const typedBody = body as Record<string, unknown>;
+
+    // Validate and extract language
+    let language: 'ja' | 'en' | undefined;
+    if (typedBody['language'] !== undefined) {
+      if (typedBody['language'] !== 'ja' && typedBody['language'] !== 'en') {
+        return null;
+      }
+      language = typedBody['language'];
+    }
+
+    // Validate and extract regenerate
+    let regenerate: boolean | undefined;
+    if (typedBody['regenerate'] !== undefined) {
+      if (typeof typedBody['regenerate'] !== 'boolean') {
+        return null;
+      }
+      regenerate = typedBody['regenerate'];
+    }
+
+    return {
+      language,
+      regenerate,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format meeting date to YYYY-MM-DD
+ *
+ * @param date - Date object
+ * @returns Formatted date string
+ */
+function formatMeetingDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day = date.getDate().toString().padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+// =============================================================================
+// Route Handler
+// =============================================================================
+
+/**
+ * POST /api/meetings/[id]/minutes/generate
+ *
+ * Generate meeting minutes from transcript using AI.
+ *
+ * Path Parameters:
+ * - id: string - Meeting ID
+ *
+ * Request Body (optional):
+ * - language: 'ja' | 'en' - Output language (default: 'ja')
+ * - regenerate: boolean - Force regeneration (future use)
+ *
+ * Response:
+ * - 200: Successfully generated minutes
+ * - 400: Invalid request body
+ * - 401: Unauthorized (not authenticated)
+ * - 404: Meeting not found or transcript not found
+ * - 500: Generation failed or internal error
+ *
+ * @example
+ * ```typescript
+ * // Request
+ * POST /api/meetings/meeting-123/minutes/generate
+ * Content-Type: application/json
+ * { "language": "ja" }
+ *
+ * // Success response
+ * {
+ *   "success": true,
+ *   "data": {
+ *     "minutes": {
+ *       "id": "min_meeting-123_1234567890",
+ *       "meetingId": "meeting-123",
+ *       "title": "Weekly Standup",
+ *       "summary": "...",
+ *       "topics": [...],
+ *       "decisions": [...],
+ *       "actionItems": [...],
+ *       "attendees": [...],
+ *       "metadata": {...}
+ *     },
+ *     "processingTimeMs": 5000,
+ *     "usage": {
+ *       "inputTokens": 1000,
+ *       "outputTokens": 500
+ *     }
+ *   }
+ * }
+ *
+ * // Error response
+ * {
+ *   "success": false,
+ *   "error": {
+ *     "code": "TRANSCRIPT_NOT_FOUND",
+ *     "message": "Transcript not found for this meeting"
+ *   }
+ * }
+ * ```
+ */
+export async function POST(
+  request: Request,
+  context: RouteContext
+): Promise<Response> {
+  try {
+    // 1. Authentication check
+    const session = await getSession();
+
+    if (session === null || !session.isAuthenticated) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Authentication required',
+        401
+      );
+    }
+
+    if (session.accessToken === undefined) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Access token not found',
+        401
+      );
+    }
+
+    // 2. Get meeting ID from path params
+    const params = await context.params;
+    const meetingId = params.id;
+
+    if (meetingId === undefined || meetingId.trim() === '') {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'Meeting ID is required',
+        400
+      );
+    }
+
+    // 3. Parse request body
+    const body = await parseRequestBody(request);
+
+    if (body === null) {
+      return createErrorResponse(
+        'INVALID_REQUEST',
+        'Invalid request body. Expected { language?: "ja" | "en", regenerate?: boolean }',
+        400
+      );
+    }
+
+    const language = body.language ?? 'ja';
+
+    // 4. Get meeting information
+    const larkClient = createLarkClient();
+    const meetingService = createMeetingService(larkClient);
+
+    let meeting;
+    try {
+      meeting = await meetingService.getMeetingById(
+        session.accessToken,
+        meetingId
+      );
+    } catch (error) {
+      if (error instanceof MeetingNotFoundError) {
+        return createErrorResponse(
+          'MEETING_NOT_FOUND',
+          `Meeting not found: ${meetingId}`,
+          404
+        );
+      }
+
+      if (error instanceof MeetingApiError) {
+        console.error('[POST /api/meetings/[id]/minutes/generate] Meeting API error:', error);
+        return createErrorResponse(
+          'MEETING_NOT_FOUND',
+          `Failed to fetch meeting: ${error.message}`,
+          404
+        );
+      }
+
+      throw error;
+    }
+
+    // 5. Get transcript
+    const transcriptService = createTranscriptService();
+
+    let transcript;
+    try {
+      transcript = await transcriptService.getTranscript(
+        session.accessToken,
+        meetingId
+      );
+    } catch (error) {
+      if (error instanceof TranscriptNotFoundError) {
+        return createErrorResponse(
+          'TRANSCRIPT_NOT_FOUND',
+          'Transcript not found for this meeting',
+          404
+        );
+      }
+
+      if (error instanceof TranscriptServiceError) {
+        console.error('[POST /api/meetings/[id]/minutes/generate] Transcript service error:', error);
+        return createErrorResponse(
+          'TRANSCRIPT_NOT_FOUND',
+          `Failed to fetch transcript: ${error.message}`,
+          404
+        );
+      }
+
+      throw error;
+    }
+
+    // 6. Generate minutes
+    const minutesService = createMinutesGenerationService();
+
+    let result: MinutesGenerationResult;
+    try {
+      result = await minutesService.generateMinutes({
+        transcript,
+        meeting: {
+          id: meeting.id,
+          title: meeting.title,
+          date: formatMeetingDate(meeting.startTime),
+          attendees: [], // Will be populated from transcript speakers
+        },
+        options: {
+          language,
+        },
+      });
+    } catch (error) {
+      if (error instanceof MinutesGenerationError) {
+        console.error('[POST /api/meetings/[id]/minutes/generate] Generation error:', error);
+
+        // Handle specific generation errors
+        if (error.code === 'MISSING_API_KEY') {
+          return createErrorResponse(
+            'GENERATION_FAILED',
+            'AI service is not configured',
+            500
+          );
+        }
+
+        if (error.code === 'INVALID_INPUT') {
+          return createErrorResponse(
+            'GENERATION_FAILED',
+            `Invalid input for generation: ${error.message}`,
+            400
+          );
+        }
+
+        return createErrorResponse(
+          'GENERATION_FAILED',
+          `Failed to generate minutes: ${error.message}`,
+          500
+        );
+      }
+
+      throw error;
+    }
+
+    // 7. Update minutes with meeting title
+    const minutesWithTitle: Minutes = {
+      ...result.minutes,
+      title: meeting.title,
+    };
+
+    // 8. Return success response
+    return createSuccessResponse({
+      ...result,
+      minutes: minutesWithTitle,
+    });
+  } catch (error) {
+    console.error('[POST /api/meetings/[id]/minutes/generate] Unexpected error:', error);
+
+    return createErrorResponse(
+      'INTERNAL_ERROR',
+      'An unexpected error occurred',
+      500
+    );
+  }
+}

--- a/src/app/api/meetings/[id]/minutes/route.ts
+++ b/src/app/api/meetings/[id]/minutes/route.ts
@@ -1,0 +1,131 @@
+/**
+ * Minutes API endpoint - Get existing minutes for a meeting
+ * @module app/api/meetings/[id]/minutes/route
+ */
+
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth/get-session';
+
+/**
+ * Error response type
+ */
+interface ErrorResponse {
+  readonly success: false;
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+  };
+}
+
+/**
+ * Route context with params
+ */
+interface RouteContext {
+  readonly params: Promise<{
+    readonly id: string;
+  }>;
+}
+
+/**
+ * Create error response
+ *
+ * @param code - Error code
+ * @param message - Error message
+ * @param statusCode - HTTP status code
+ * @returns NextResponse with error payload
+ */
+function createErrorResponse(
+  code: string,
+  message: string,
+  statusCode: number
+): NextResponse<ErrorResponse> {
+  const response: ErrorResponse = {
+    success: false,
+    error: {
+      code,
+      message,
+    },
+  };
+
+  return NextResponse.json(response, { status: statusCode });
+}
+
+/**
+ * GET /api/meetings/[id]/minutes
+ *
+ * Get existing minutes for a specific meeting.
+ * Currently returns 404 as minutes storage is not yet implemented.
+ * This endpoint is prepared for future database integration.
+ *
+ * Path Parameters:
+ * - id: string - Meeting ID
+ *
+ * Response:
+ * - 401: Unauthorized (not authenticated)
+ * - 404: Minutes not found (current default behavior)
+ *
+ * @example
+ * ```typescript
+ * // Error response (current behavior)
+ * {
+ *   "success": false,
+ *   "error": {
+ *     "code": "MINUTES_NOT_FOUND",
+ *     "message": "Minutes not found for this meeting"
+ *   }
+ * }
+ * ```
+ */
+export async function GET(
+  _request: Request,
+  context: RouteContext
+): Promise<Response> {
+  try {
+    // 1. Authentication check
+    const session = await getSession();
+
+    if (session === null || !session.isAuthenticated) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Authentication required',
+        401
+      );
+    }
+
+    if (session.accessToken === undefined) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Access token not found',
+        401
+      );
+    }
+
+    // 2. Get meeting ID from path params
+    const params = await context.params;
+    const meetingId = params.id;
+
+    if (meetingId === undefined || meetingId.trim() === '') {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'Meeting ID is required',
+        400
+      );
+    }
+
+    // 3. Future: Query database for existing minutes
+    // For now, return 404 as minutes storage is not implemented
+    return createErrorResponse(
+      'MINUTES_NOT_FOUND',
+      'Minutes not found for this meeting',
+      404
+    );
+  } catch (error) {
+    console.error('[GET /api/meetings/[id]/minutes] Error:', error);
+
+    return createErrorResponse(
+      'INTERNAL_ERROR',
+      'An unexpected error occurred',
+      500
+    );
+  }
+}

--- a/src/components/minutes/ActionItemList.tsx
+++ b/src/components/minutes/ActionItemList.tsx
@@ -1,0 +1,529 @@
+'use client';
+
+import { memo, useState, useCallback, useMemo } from 'react';
+import { Avatar, Badge } from '@/components/ui';
+import type {
+  ActionItem,
+  ActionItemStatus,
+  Priority,
+  Speaker,
+} from '@/types/minutes';
+
+/**
+ * Get priority badge variant
+ */
+function getPriorityVariant(
+  priority: Priority
+): 'error' | 'warning' | 'default' {
+  const variants: Record<Priority, 'error' | 'warning' | 'default'> = {
+    high: 'error',
+    medium: 'warning',
+    low: 'default',
+  };
+  return variants[priority];
+}
+
+/**
+ * Get priority label
+ */
+function getPriorityLabel(priority: Priority): string {
+  const labels: Record<Priority, string> = {
+    high: 'High',
+    medium: 'Medium',
+    low: 'Low',
+  };
+  return labels[priority];
+}
+
+/**
+ * Get status label
+ */
+function getStatusLabel(status: ActionItemStatus): string {
+  const labels: Record<ActionItemStatus, string> = {
+    pending: 'Pending',
+    in_progress: 'In Progress',
+    completed: 'Completed',
+  };
+  return labels[status];
+}
+
+/**
+ * Get status icon
+ */
+function StatusIcon({
+  status,
+  className = '',
+}: {
+  readonly status: ActionItemStatus;
+  readonly className?: string;
+}): JSX.Element {
+  switch (status) {
+    case 'completed':
+      return (
+        <svg
+          className={`w-4 h-4 text-green-500 ${className}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M5 13l4 4L19 7"
+          />
+        </svg>
+      );
+    case 'in_progress':
+      return (
+        <svg
+          className={`w-4 h-4 text-yellow-500 ${className}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      );
+    default:
+      return (
+        <svg
+          className={`w-4 h-4 text-gray-400 ${className}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+          />
+        </svg>
+      );
+  }
+}
+
+/**
+ * Props for ActionItemCard component
+ */
+export interface ActionItemCardProps {
+  /** Action item data to display */
+  readonly item: ActionItem;
+  /** Callback when status is changed */
+  readonly onStatusChange?: ((id: string, status: ActionItemStatus) => void) | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * ActionItemCard component
+ *
+ * @description Displays a single action item with priority, assignee, and due date
+ * @example
+ * ```tsx
+ * <ActionItemCard
+ *   item={{
+ *     id: '1',
+ *     content: 'Prepare Q4 presentation',
+ *     assignee: { id: '1', name: 'John Doe' },
+ *     dueDate: '2024-12-31',
+ *     priority: 'high',
+ *     status: 'pending',
+ *   }}
+ * />
+ * ```
+ */
+function ActionItemCardInner({
+  item,
+  onStatusChange,
+  className = '',
+}: ActionItemCardProps): JSX.Element {
+  const handleStatusClick = useCallback(() => {
+    if (onStatusChange === undefined) return;
+
+    // Cycle through statuses: pending -> in_progress -> completed -> pending
+    const nextStatus: Record<ActionItemStatus, ActionItemStatus> = {
+      pending: 'in_progress',
+      in_progress: 'completed',
+      completed: 'pending',
+    };
+    onStatusChange(item.id, nextStatus[item.status]);
+  }, [item.id, item.status, onStatusChange]);
+
+  const isInteractive = onStatusChange !== undefined;
+
+  return (
+    <article
+      className={`
+        p-4 border border-lark-border rounded-lg bg-white
+        transition-all duration-200 hover:shadow-sm
+        ${item.status === 'completed' ? 'opacity-60' : ''}
+        ${className}
+      `}
+      aria-labelledby={`action-item-${item.id}`}
+    >
+      {/* Header row */}
+      <div className="flex items-start justify-between gap-3 mb-2">
+        {/* Status icon and content */}
+        <div className="flex items-start gap-3 flex-1 min-w-0">
+          {/* Status indicator */}
+          <button
+            type="button"
+            onClick={isInteractive ? handleStatusClick : undefined}
+            disabled={!isInteractive}
+            className={`
+              flex-shrink-0 p-1 rounded transition-colors
+              ${isInteractive ? 'hover:bg-gray-100 cursor-pointer' : 'cursor-default'}
+              focus:outline-none focus:ring-2 focus:ring-lark-primary focus:ring-offset-2
+            `}
+            title={`Status: ${getStatusLabel(item.status)}${isInteractive ? ' (click to change)' : ''}`}
+            aria-label={`Status: ${getStatusLabel(item.status)}`}
+          >
+            <StatusIcon status={item.status} />
+          </button>
+
+          {/* Content */}
+          <p
+            id={`action-item-${item.id}`}
+            className={`
+              text-sm text-lark-text flex-1
+              ${item.status === 'completed' ? 'line-through text-gray-500' : ''}
+            `}
+          >
+            {item.content}
+          </p>
+        </div>
+
+        {/* Priority badge */}
+        <Badge variant={getPriorityVariant(item.priority)} className="flex-shrink-0">
+          {getPriorityLabel(item.priority)}
+        </Badge>
+      </div>
+
+      {/* Meta row */}
+      <div className="flex items-center gap-4 ml-8 text-sm">
+        {/* Assignee */}
+        {item.assignee !== undefined && (
+          <div className="flex items-center gap-2">
+            <Avatar name={item.assignee.name} size="sm" />
+            <span className="text-gray-600">{item.assignee.name}</span>
+          </div>
+        )}
+
+        {/* Due date */}
+        {item.dueDate !== undefined && (
+          <div className="flex items-center gap-1 text-gray-500">
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+            <time dateTime={item.dueDate}>{item.dueDate}</time>
+          </div>
+        )}
+
+        {/* Status badge for small screens */}
+        <span className="text-xs text-gray-400 ml-auto">
+          {getStatusLabel(item.status)}
+        </span>
+      </div>
+    </article>
+  );
+}
+
+export const ActionItemCard = memo(ActionItemCardInner);
+
+/**
+ * Filter value for status (includes 'all' for no filter)
+ */
+export type StatusFilterValue = ActionItemStatus | 'all';
+
+/**
+ * Filter options for action items
+ */
+export interface ActionItemFilterOptions {
+  /** Filter by status */
+  readonly status?: StatusFilterValue | undefined;
+  /** Filter by assignee ID (use 'all' for no filter) */
+  readonly assigneeId?: string | undefined;
+}
+
+/**
+ * Props for ActionItemFilters component
+ */
+export interface ActionItemFiltersProps {
+  /** Current filter options */
+  readonly filters: ActionItemFilterOptions;
+  /** Callback when filters change */
+  readonly onFiltersChange: (filters: ActionItemFilterOptions) => void;
+  /** List of unique assignees for the filter dropdown */
+  readonly assignees: readonly Speaker[];
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * ActionItemFilters component
+ *
+ * @description Filter controls for action items
+ */
+export function ActionItemFilters({
+  filters,
+  onFiltersChange,
+  assignees,
+  className = '',
+}: ActionItemFiltersProps): JSX.Element {
+  const handleStatusChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const value = event.target.value;
+      onFiltersChange({
+        ...filters,
+        status: value === 'all' ? 'all' : (value as ActionItemStatus),
+      });
+    },
+    [filters, onFiltersChange]
+  );
+
+  const handleAssigneeChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const value = event.target.value;
+      onFiltersChange({
+        ...filters,
+        assigneeId: value === 'all' ? 'all' : value,
+      });
+    },
+    [filters, onFiltersChange]
+  );
+
+  return (
+    <div className={`flex items-center gap-4 ${className}`}>
+      {/* Status filter */}
+      <div className="flex items-center gap-2">
+        <label
+          htmlFor="status-filter"
+          className="text-sm text-gray-600"
+        >
+          Status:
+        </label>
+        <select
+          id="status-filter"
+          value={filters.status ?? 'all'}
+          onChange={handleStatusChange}
+          className="
+            text-sm border border-lark-border rounded-lg
+            px-3 py-1.5 bg-white
+            focus:outline-none focus:ring-2 focus:ring-lark-primary focus:border-lark-primary
+          "
+        >
+          <option value="all">All</option>
+          <option value="pending">Pending</option>
+          <option value="in_progress">In Progress</option>
+          <option value="completed">Completed</option>
+        </select>
+      </div>
+
+      {/* Assignee filter */}
+      {assignees.length > 0 && (
+        <div className="flex items-center gap-2">
+          <label
+            htmlFor="assignee-filter"
+            className="text-sm text-gray-600"
+          >
+            Assignee:
+          </label>
+          <select
+            id="assignee-filter"
+            value={filters.assigneeId ?? 'all'}
+            onChange={handleAssigneeChange}
+            className="
+              text-sm border border-lark-border rounded-lg
+              px-3 py-1.5 bg-white
+              focus:outline-none focus:ring-2 focus:ring-lark-primary focus:border-lark-primary
+            "
+          >
+            <option value="all">All</option>
+            {assignees.map((assignee) => (
+              <option key={assignee.id} value={assignee.id}>
+                {assignee.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Props for ActionItemList component
+ */
+export interface ActionItemListProps {
+  /** List of action items to display */
+  readonly actionItems: readonly ActionItem[];
+  /** Whether to show filters */
+  readonly showFilters?: boolean | undefined;
+  /** Callback when an item's status is changed */
+  readonly onStatusChange?: ((id: string, status: ActionItemStatus) => void) | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * ActionItemList component
+ *
+ * @description Displays a list of action items with filtering capabilities
+ * @example
+ * ```tsx
+ * <ActionItemList
+ *   actionItems={minutes.actionItems}
+ *   showFilters
+ *   onStatusChange={handleStatusChange}
+ * />
+ * ```
+ */
+export function ActionItemList({
+  actionItems,
+  showFilters = false,
+  onStatusChange,
+  className = '',
+}: ActionItemListProps): JSX.Element {
+  const [filters, setFilters] = useState<ActionItemFilterOptions>({
+    status: 'all',
+    assigneeId: 'all',
+  });
+
+  // Get unique assignees
+  const uniqueAssignees = useMemo(() => {
+    const assigneeMap = new Map<string, Speaker>();
+    for (const item of actionItems) {
+      if (item.assignee !== undefined && !assigneeMap.has(item.assignee.id)) {
+        assigneeMap.set(item.assignee.id, item.assignee);
+      }
+    }
+    return Array.from(assigneeMap.values());
+  }, [actionItems]);
+
+  // Filter action items
+  const filteredItems = useMemo(() => {
+    return actionItems.filter((item) => {
+      // Filter by status
+      if (filters.status !== undefined && filters.status !== 'all') {
+        if (item.status !== filters.status) {
+          return false;
+        }
+      }
+
+      // Filter by assignee
+      if (filters.assigneeId !== undefined && filters.assigneeId !== 'all') {
+        if (item.assignee?.id !== filters.assigneeId) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }, [actionItems, filters]);
+
+  if (actionItems.length === 0) {
+    return (
+      <div
+        className={`
+          p-8 text-center text-gray-500
+          border border-dashed border-lark-border rounded-lg
+          ${className}
+        `}
+      >
+        <svg
+          className="w-12 h-12 mx-auto mb-3 text-gray-300"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+          />
+        </svg>
+        <p className="text-sm">No action items</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      {/* Filters */}
+      {showFilters && (
+        <div className="mb-4">
+          <ActionItemFilters
+            filters={filters}
+            onFiltersChange={setFilters}
+            assignees={uniqueAssignees}
+          />
+        </div>
+      )}
+
+      {/* Summary */}
+      <div className="mb-4 flex items-center gap-4 text-sm text-gray-500">
+        <span>
+          {filteredItems.length} of {actionItems.length} items
+        </span>
+        <span className="text-gray-300">|</span>
+        <span className="flex items-center gap-1">
+          <span className="w-2 h-2 rounded-full bg-green-500" />
+          {actionItems.filter((i) => i.status === 'completed').length} completed
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="w-2 h-2 rounded-full bg-yellow-500" />
+          {actionItems.filter((i) => i.status === 'in_progress').length} in progress
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="w-2 h-2 rounded-full bg-gray-400" />
+          {actionItems.filter((i) => i.status === 'pending').length} pending
+        </span>
+      </div>
+
+      {/* List */}
+      {filteredItems.length === 0 ? (
+        <div className="p-8 text-center text-gray-500 border border-dashed border-lark-border rounded-lg">
+          <p className="text-sm">No items match the selected filters</p>
+        </div>
+      ) : (
+        <div
+          className="space-y-3"
+          role="list"
+          aria-label="Action items"
+        >
+          {filteredItems.map((item) => (
+            <div key={item.id} role="listitem">
+              <ActionItemCard
+                item={item}
+                onStatusChange={onStatusChange}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/minutes/DecisionList.tsx
+++ b/src/components/minutes/DecisionList.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import { memo, useState, useCallback } from 'react';
+import type { DecisionItem, TopicSegment } from '@/types/minutes';
+
+/**
+ * Format timestamp in milliseconds to MM:SS or HH:MM:SS format
+ */
+function formatTimestamp(ms: number): string {
+  if (ms < 0) {
+    return '00:00';
+  }
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const pad = (n: number): string => n.toString().padStart(2, '0');
+
+  if (hours > 0) {
+    return `${hours}:${pad(minutes)}:${pad(seconds)}`;
+  }
+
+  return `${pad(minutes)}:${pad(seconds)}`;
+}
+
+/**
+ * Props for DecisionItemCard component
+ */
+export interface DecisionItemCardProps {
+  /** Decision data to display */
+  readonly decision: DecisionItem;
+  /** Related topic (optional) */
+  readonly relatedTopic?: TopicSegment | undefined;
+  /** Callback when related topic link is clicked */
+  readonly onTopicLinkClick?: ((topicId: string) => void) | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * DecisionItemCard component
+ *
+ * @description Displays a single decision with expandable context
+ * @example
+ * ```tsx
+ * <DecisionItemCard
+ *   decision={{
+ *     id: '1',
+ *     content: 'Approved Q4 budget',
+ *     context: 'After reviewing projections and growth plans.',
+ *     decidedAt: 300000,
+ *   }}
+ * />
+ * ```
+ */
+function DecisionItemCardInner({
+  decision,
+  relatedTopic,
+  onTopicLinkClick,
+  className = '',
+}: DecisionItemCardProps): JSX.Element {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const hasContext = decision.context.length > 0;
+
+  const handleToggle = useCallback(() => {
+    if (hasContext) {
+      setIsExpanded((prev) => !prev);
+    }
+  }, [hasContext]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if ((event.key === 'Enter' || event.key === ' ') && hasContext) {
+        event.preventDefault();
+        handleToggle();
+      }
+    },
+    [hasContext, handleToggle]
+  );
+
+  const handleTopicLinkClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      if (decision.relatedTopicId !== undefined) {
+        onTopicLinkClick?.(decision.relatedTopicId);
+      }
+    },
+    [decision.relatedTopicId, onTopicLinkClick]
+  );
+
+  return (
+    <article
+      className={`
+        border-l-4 border-lark-primary bg-blue-50 rounded-r-lg
+        transition-all duration-200
+        ${hasContext ? 'cursor-pointer hover:bg-blue-100' : ''}
+        ${className}
+      `}
+      onClick={hasContext ? handleToggle : undefined}
+      onKeyDown={hasContext ? handleKeyDown : undefined}
+      tabIndex={hasContext ? 0 : undefined}
+      role={hasContext ? 'button' : 'article'}
+      aria-expanded={hasContext ? isExpanded : undefined}
+      aria-controls={hasContext ? `decision-details-${decision.id}` : undefined}
+      aria-labelledby={`decision-content-${decision.id}`}
+    >
+      {/* Main content */}
+      <div className="p-4">
+        <div className="flex items-start justify-between gap-3">
+          {/* Decision content */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start gap-2">
+              {/* Check icon */}
+              <svg
+                className="w-5 h-5 text-lark-primary flex-shrink-0 mt-0.5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <div className="flex-1">
+                <p
+                  id={`decision-content-${decision.id}`}
+                  className="text-sm font-medium text-lark-text"
+                >
+                  {decision.content}
+                </p>
+                <p className="text-xs text-gray-500 mt-1">
+                  Decided at {formatTimestamp(decision.decidedAt)}
+                </p>
+              </div>
+            </div>
+
+            {/* Related topic link */}
+            {relatedTopic !== undefined && onTopicLinkClick !== undefined && (
+              <button
+                type="button"
+                onClick={handleTopicLinkClick}
+                className="
+                  mt-2 ml-7 text-xs text-lark-primary hover:underline
+                  flex items-center gap-1
+                  focus:outline-none focus:underline
+                "
+              >
+                <svg
+                  className="w-3 h-3"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                  />
+                </svg>
+                <span>{relatedTopic.title}</span>
+              </button>
+            )}
+          </div>
+
+          {/* Expand indicator */}
+          {hasContext && (
+            <svg
+              className={`
+                w-4 h-4 text-gray-400 flex-shrink-0 transition-transform duration-200
+                ${isExpanded ? 'rotate-180' : ''}
+              `}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          )}
+        </div>
+      </div>
+
+      {/* Expandable context */}
+      {hasContext && isExpanded && (
+        <div
+          id={`decision-details-${decision.id}`}
+          className="px-4 pb-4 ml-7"
+          role="region"
+          aria-label="Decision context"
+        >
+          <div>
+            <h4 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-1">
+              Context
+            </h4>
+            <p className="text-sm text-gray-700">{decision.context}</p>
+          </div>
+        </div>
+      )}
+    </article>
+  );
+}
+
+export const DecisionItemCard = memo(DecisionItemCardInner);
+
+/**
+ * Props for DecisionList component
+ */
+export interface DecisionListProps {
+  /** List of decisions to display */
+  readonly decisions: readonly DecisionItem[];
+  /** Map of topics by ID for linking */
+  readonly topicsMap?: ReadonlyMap<string, TopicSegment> | undefined;
+  /** Callback when a topic link is clicked */
+  readonly onTopicLinkClick?: ((topicId: string) => void) | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * DecisionList component
+ *
+ * @description Displays a list of decisions made during the meeting
+ * @example
+ * ```tsx
+ * <DecisionList
+ *   decisions={minutes.decisions}
+ *   topicsMap={topicsMap}
+ *   onTopicLinkClick={handleTopicClick}
+ * />
+ * ```
+ */
+export function DecisionList({
+  decisions,
+  topicsMap,
+  onTopicLinkClick,
+  className = '',
+}: DecisionListProps): JSX.Element {
+  if (decisions.length === 0) {
+    return (
+      <div
+        className={`
+          p-8 text-center text-gray-500
+          border border-dashed border-lark-border rounded-lg
+          ${className}
+        `}
+      >
+        <svg
+          className="w-12 h-12 mx-auto mb-3 text-gray-300"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        <p className="text-sm">No decisions recorded</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`space-y-3 ${className}`}
+      role="list"
+      aria-label="Meeting decisions"
+    >
+      {decisions.map((decision) => {
+        const relatedTopic =
+          decision.relatedTopicId !== undefined && topicsMap !== undefined
+            ? topicsMap.get(decision.relatedTopicId)
+            : undefined;
+
+        return (
+          <div key={decision.id} role="listitem">
+            <DecisionItemCard
+              decision={decision}
+              relatedTopic={relatedTopic}
+              onTopicLinkClick={onTopicLinkClick}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/minutes/GenerateButton.tsx
+++ b/src/components/minutes/GenerateButton.tsx
@@ -1,0 +1,376 @@
+'use client';
+
+import { memo, useCallback } from 'react';
+
+/**
+ * Generation state type
+ */
+export type GenerationStatus = 'idle' | 'generating' | 'completed' | 'error';
+
+/**
+ * Generation state
+ */
+export interface GenerationState {
+  /** Current status */
+  readonly status: GenerationStatus;
+  /** Progress percentage (0-100) */
+  readonly progress?: number | undefined;
+  /** Current step description */
+  readonly currentStep?: string | undefined;
+  /** Error message */
+  readonly error?: string | undefined;
+}
+
+/**
+ * Props for GenerateButton component
+ */
+export interface GenerateButtonProps {
+  /** Current generation state */
+  readonly state: GenerationState;
+  /** Callback when generate button is clicked */
+  readonly onGenerate: () => void;
+  /** Callback when regenerate button is clicked */
+  readonly onRegenerate?: (() => void) | undefined;
+  /** Whether minutes already exist (shows regenerate option) */
+  readonly hasExistingMinutes?: boolean | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Spinner component
+ */
+function Spinner({ className = '' }: { readonly className?: string }): JSX.Element {
+  return (
+    <svg
+      className={`animate-spin ${className}`}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Progress bar component
+ */
+function ProgressBar({
+  progress,
+  className = '',
+}: {
+  readonly progress: number;
+  readonly className?: string;
+}): JSX.Element {
+  return (
+    <div
+      className={`w-full bg-gray-200 rounded-full h-2 overflow-hidden ${className}`}
+      role="progressbar"
+      aria-valuenow={progress}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div
+        className="h-full bg-lark-primary transition-all duration-300 ease-out"
+        style={{ width: `${Math.min(100, Math.max(0, progress))}%` }}
+      />
+    </div>
+  );
+}
+
+/**
+ * GenerateButton component
+ *
+ * @description Button to trigger AI minutes generation with progress display
+ * @example
+ * ```tsx
+ * <GenerateButton
+ *   state={{ status: 'idle' }}
+ *   onGenerate={handleGenerate}
+ *   onRegenerate={handleRegenerate}
+ *   hasExistingMinutes={false}
+ * />
+ * ```
+ */
+function GenerateButtonInner({
+  state,
+  onGenerate,
+  onRegenerate,
+  hasExistingMinutes = false,
+  className = '',
+}: GenerateButtonProps): JSX.Element {
+  const handleClick = useCallback(() => {
+    if (state.status === 'generating') return;
+    onGenerate();
+  }, [state.status, onGenerate]);
+
+  const handleRegenerate = useCallback(() => {
+    if (state.status === 'generating') return;
+    onRegenerate?.();
+  }, [state.status, onRegenerate]);
+
+  const isGenerating = state.status === 'generating';
+  const isCompleted = state.status === 'completed';
+  const isError = state.status === 'error';
+
+  // Show regenerate UI when completed and has existing minutes
+  if (isCompleted && hasExistingMinutes && onRegenerate !== undefined) {
+    return (
+      <div className={`flex items-center gap-3 ${className}`}>
+        {/* Success indicator */}
+        <div className="flex items-center gap-2 text-sm text-green-600">
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+          <span>Minutes generated</span>
+        </div>
+
+        {/* Regenerate button */}
+        <button
+          type="button"
+          onClick={handleRegenerate}
+          className="
+            flex items-center gap-2 px-4 py-2
+            text-sm font-medium text-gray-600
+            border border-lark-border rounded-lg
+            hover:bg-gray-50 transition-colors
+            focus:outline-none focus:ring-2 focus:ring-lark-primary focus:ring-offset-2
+          "
+          aria-label="Regenerate minutes"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+          <span>Regenerate</span>
+        </button>
+      </div>
+    );
+  }
+
+  // Error state
+  if (isError) {
+    return (
+      <div className={`space-y-3 ${className}`}>
+        {/* Error message */}
+        <div className="flex items-center gap-2 text-sm text-red-600">
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <span>{state.error ?? 'Generation failed'}</span>
+        </div>
+
+        {/* Retry button */}
+        <button
+          type="button"
+          onClick={handleClick}
+          className="
+            flex items-center gap-2 px-4 py-2
+            text-sm font-medium text-white
+            bg-lark-primary rounded-lg
+            hover:bg-blue-600 transition-colors
+            focus:outline-none focus:ring-2 focus:ring-lark-primary focus:ring-offset-2
+          "
+          aria-label="Retry generation"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+          <span>Retry</span>
+        </button>
+      </div>
+    );
+  }
+
+  // Generating state
+  if (isGenerating) {
+    return (
+      <div className={`space-y-3 ${className}`}>
+        {/* Progress indicator */}
+        <div className="flex items-center gap-3">
+          <Spinner className="w-5 h-5 text-lark-primary" />
+          <span className="text-sm text-gray-600">
+            {state.currentStep ?? 'Generating minutes...'}
+          </span>
+        </div>
+
+        {/* Progress bar */}
+        {state.progress !== undefined && (
+          <ProgressBar progress={state.progress} />
+        )}
+      </div>
+    );
+  }
+
+  // Idle state - show generate button
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={`
+        flex items-center gap-2 px-4 py-2
+        text-sm font-medium text-white
+        bg-lark-primary rounded-lg
+        hover:bg-blue-600 transition-colors
+        focus:outline-none focus:ring-2 focus:ring-lark-primary focus:ring-offset-2
+        ${className}
+      `}
+      aria-label={hasExistingMinutes ? 'Regenerate minutes' : 'Generate minutes'}
+    >
+      {/* Sparkle icon */}
+      <svg
+        className="w-4 h-4"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"
+        />
+      </svg>
+      <span>{hasExistingMinutes ? 'Regenerate Minutes' : 'Generate Minutes'}</span>
+    </button>
+  );
+}
+
+export const GenerateButton = memo(GenerateButtonInner);
+
+/**
+ * Props for GenerateMinutesCard component
+ */
+export interface GenerateMinutesCardProps {
+  /** Current generation state */
+  readonly state: GenerationState;
+  /** Callback when generate button is clicked */
+  readonly onGenerate: () => void;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * GenerateMinutesCard component
+ *
+ * @description Card prompting user to generate AI minutes
+ * @example
+ * ```tsx
+ * <GenerateMinutesCard
+ *   state={{ status: 'idle' }}
+ *   onGenerate={handleGenerate}
+ * />
+ * ```
+ */
+export function GenerateMinutesCard({
+  state,
+  onGenerate,
+  className = '',
+}: GenerateMinutesCardProps): JSX.Element {
+  return (
+    <div
+      className={`
+        p-8 text-center
+        border border-dashed border-lark-border rounded-lg
+        bg-gradient-to-b from-white to-gray-50
+        ${className}
+      `}
+    >
+      {/* Icon */}
+      <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-blue-100 flex items-center justify-center">
+        <svg
+          className="w-8 h-8 text-lark-primary"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+      </div>
+
+      {/* Title */}
+      <h3 className="text-lg font-medium text-lark-text mb-2">
+        Generate AI Minutes
+      </h3>
+
+      {/* Description */}
+      <p className="text-sm text-gray-500 mb-6 max-w-md mx-auto">
+        Use AI to automatically generate meeting minutes including topics,
+        decisions, and action items from the transcript.
+      </p>
+
+      {/* Generate button */}
+      <div className="flex justify-center">
+        <GenerateButton
+          state={state}
+          onGenerate={onGenerate}
+          hasExistingMinutes={false}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/minutes/MinutesSkeleton.tsx
+++ b/src/components/minutes/MinutesSkeleton.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { Skeleton } from '@/components/ui';
+
+/**
+ * Props for MinutesSkeleton component
+ */
+export interface MinutesSkeletonProps {
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Topic section skeleton
+ */
+function TopicSectionSkeleton(): JSX.Element {
+  return (
+    <div className="p-4 border border-lark-border rounded-lg bg-white">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <Skeleton className="h-5 w-1/3" />
+        <Skeleton className="h-4 w-24" />
+      </div>
+
+      {/* Summary */}
+      <Skeleton className="h-4 w-full mb-2" />
+      <Skeleton className="h-4 w-4/5 mb-4" />
+
+      {/* Key points */}
+      <div className="space-y-2 pl-4">
+        <div className="flex items-start gap-2">
+          <Skeleton className="h-2 w-2 rounded-full mt-1.5" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+        <div className="flex items-start gap-2">
+          <Skeleton className="h-2 w-2 rounded-full mt-1.5" />
+          <Skeleton className="h-4 w-2/3" />
+        </div>
+        <div className="flex items-start gap-2">
+          <Skeleton className="h-2 w-2 rounded-full mt-1.5" />
+          <Skeleton className="h-4 w-1/2" />
+        </div>
+      </div>
+
+      {/* Speakers */}
+      <div className="flex items-center gap-2 mt-4 pt-3 border-t border-gray-100">
+        <div className="flex -space-x-2">
+          <Skeleton className="h-6 w-6 rounded-full" />
+          <Skeleton className="h-6 w-6 rounded-full" />
+          <Skeleton className="h-6 w-6 rounded-full" />
+        </div>
+        <Skeleton className="h-3 w-16" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Decision item skeleton
+ */
+function DecisionItemSkeleton(): JSX.Element {
+  return (
+    <div className="p-4 border-l-4 border-lark-primary bg-blue-50 rounded-r-lg">
+      <Skeleton className="h-5 w-3/4 mb-2" />
+      <Skeleton className="h-4 w-1/2" />
+    </div>
+  );
+}
+
+/**
+ * Action item skeleton
+ */
+function ActionItemSkeleton(): JSX.Element {
+  return (
+    <div className="p-4 border border-lark-border rounded-lg bg-white">
+      <div className="flex items-start justify-between mb-2">
+        <div className="flex items-center gap-2 flex-1">
+          <Skeleton className="h-4 w-4" />
+          <Skeleton className="h-5 w-2/3" />
+        </div>
+        <Skeleton className="h-5 w-12 rounded-full" />
+      </div>
+      <div className="flex items-center gap-4 text-sm">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-6 w-6 rounded-full" />
+          <Skeleton className="h-4 w-20" />
+        </div>
+        <Skeleton className="h-4 w-24" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * MinutesSkeleton component
+ *
+ * @description Loading skeleton for minutes viewer
+ * @example
+ * ```tsx
+ * <MinutesSkeleton />
+ * ```
+ */
+export function MinutesSkeleton({
+  className = '',
+}: MinutesSkeletonProps): JSX.Element {
+  return (
+    <div
+      className={`bg-white rounded-lg border border-lark-border ${className}`}
+      aria-busy="true"
+      aria-label="Loading minutes..."
+    >
+      {/* Header */}
+      <div className="p-4 border-b border-lark-border">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-5 w-5" />
+            <Skeleton className="h-6 w-48" />
+          </div>
+          <Skeleton className="h-9 w-24 rounded-lg" />
+        </div>
+
+        {/* Overall summary skeleton */}
+        <div className="bg-gray-50 rounded-lg p-4">
+          <Skeleton className="h-4 w-16 mb-2" />
+          <Skeleton className="h-4 w-full mb-1" />
+          <Skeleton className="h-4 w-full mb-1" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+      </div>
+
+      {/* Tabs skeleton */}
+      <div className="border-b border-lark-border">
+        <div className="flex gap-4 px-4">
+          <Skeleton className="h-10 w-20" />
+          <Skeleton className="h-10 w-20" />
+          <Skeleton className="h-10 w-24" />
+        </div>
+      </div>
+
+      {/* Content skeleton */}
+      <div className="p-4">
+        {/* Topics tab content */}
+        <div className="space-y-4">
+          <TopicSectionSkeleton />
+          <TopicSectionSkeleton />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Props for MinutesContentSkeleton component
+ */
+export interface MinutesContentSkeletonProps {
+  /** Content type */
+  readonly type: 'topics' | 'decisions' | 'actions';
+  /** Number of items to show */
+  readonly count?: number | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * MinutesContentSkeleton component
+ *
+ * @description Skeleton for specific content sections
+ * @example
+ * ```tsx
+ * <MinutesContentSkeleton type="topics" count={3} />
+ * ```
+ */
+export function MinutesContentSkeleton({
+  type,
+  count = 3,
+  className = '',
+}: MinutesContentSkeletonProps): JSX.Element {
+  const items = Array.from({ length: count }, (_, i) => i);
+
+  return (
+    <div className={`space-y-4 ${className}`} aria-busy="true">
+      {items.map((i) => {
+        switch (type) {
+          case 'topics':
+            return <TopicSectionSkeleton key={i} />;
+          case 'decisions':
+            return <DecisionItemSkeleton key={i} />;
+          case 'actions':
+            return <ActionItemSkeleton key={i} />;
+        }
+      })}
+    </div>
+  );
+}

--- a/src/components/minutes/MinutesViewer.tsx
+++ b/src/components/minutes/MinutesViewer.tsx
@@ -1,0 +1,403 @@
+'use client';
+
+import { memo, useState, useCallback, useMemo } from 'react';
+import type {
+  Minutes,
+  ActionItemStatus,
+  TopicSegment,
+} from '@/types/minutes';
+import { minutesToMarkdown } from '@/types/minutes';
+import { TopicList } from './TopicSection';
+import { DecisionList } from './DecisionList';
+import { ActionItemList } from './ActionItemList';
+import { MinutesSkeleton } from './MinutesSkeleton';
+import {
+  GenerateButton,
+  GenerateMinutesCard,
+  type GenerationState,
+} from './GenerateButton';
+
+/**
+ * Tab type for MinutesViewer
+ */
+export type MinutesTab = 'topics' | 'decisions' | 'actions';
+
+/**
+ * Props for MinutesViewer component
+ */
+export interface MinutesViewerProps {
+  /** Minutes data to display */
+  readonly minutes?: Minutes | undefined;
+  /** Loading state */
+  readonly isLoading?: boolean | undefined;
+  /** Generation state */
+  readonly generationState?: GenerationState | undefined;
+  /** Callback to generate minutes */
+  readonly onGenerate?: (() => void) | undefined;
+  /** Callback to regenerate minutes */
+  readonly onRegenerate?: (() => void) | undefined;
+  /** Callback when a topic is clicked */
+  readonly onTopicClick?: ((topic: TopicSegment) => void) | undefined;
+  /** Callback when action item status changes */
+  readonly onActionStatusChange?: ((id: string, status: ActionItemStatus) => void) | undefined;
+  /** Initial active tab */
+  readonly initialTab?: MinutesTab | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Tab button component
+ */
+function TabButton({
+  label,
+  count,
+  isActive,
+  onClick,
+}: {
+  readonly label: string;
+  readonly count: number;
+  readonly isActive: boolean;
+  readonly onClick: () => void;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`
+        px-4 py-3 text-sm font-medium border-b-2 transition-colors
+        focus:outline-none focus:ring-2 focus:ring-lark-primary focus:ring-inset
+        ${
+          isActive
+            ? 'text-lark-primary border-lark-primary'
+            : 'text-gray-500 border-transparent hover:text-gray-700 hover:border-gray-300'
+        }
+      `}
+      role="tab"
+      aria-selected={isActive}
+    >
+      {label}
+      <span
+        className={`
+          ml-2 px-2 py-0.5 text-xs rounded-full
+          ${isActive ? 'bg-lark-primary text-white' : 'bg-gray-100 text-gray-600'}
+        `}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Format duration in milliseconds to human-readable format
+ */
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+
+  return `${minutes}m`;
+}
+
+/**
+ * MinutesViewer component
+ *
+ * @description Main component for displaying AI-generated meeting minutes
+ * @example
+ * ```tsx
+ * <MinutesViewer
+ *   minutes={minutesData}
+ *   isLoading={false}
+ *   onTopicClick={handleTopicClick}
+ *   onActionStatusChange={handleStatusChange}
+ * />
+ * ```
+ */
+function MinutesViewerInner({
+  minutes,
+  isLoading = false,
+  generationState,
+  onGenerate,
+  onRegenerate,
+  onTopicClick,
+  onActionStatusChange,
+  initialTab = 'topics',
+  className = '',
+}: MinutesViewerProps): JSX.Element {
+  const [activeTab, setActiveTab] = useState<MinutesTab>(initialTab);
+  const [isCopied, setIsCopied] = useState(false);
+
+  // Create topics map for linking
+  const topicsMap = useMemo(() => {
+    if (minutes === undefined) return new Map<string, TopicSegment>();
+    const map = new Map<string, TopicSegment>();
+    for (const topic of minutes.topics) {
+      map.set(topic.id, topic);
+    }
+    return map;
+  }, [minutes]);
+
+  // Handle topic link click from decisions
+  const handleTopicLinkClick = useCallback(
+    (topicId: string) => {
+      const topic = topicsMap.get(topicId);
+      if (topic !== undefined) {
+        setActiveTab('topics');
+        onTopicClick?.(topic);
+      }
+    },
+    [topicsMap, onTopicClick]
+  );
+
+  // Handle copy to clipboard
+  const handleCopy = useCallback(() => {
+    if (minutes === undefined) return;
+
+    const markdown = minutesToMarkdown(minutes);
+    navigator.clipboard.writeText(markdown).then(
+      () => {
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), 2000);
+      },
+      (error) => {
+        console.error('Failed to copy:', error);
+      }
+    );
+  }, [minutes]);
+
+  // Show loading skeleton
+  if (isLoading) {
+    return <MinutesSkeleton className={className} />;
+  }
+
+  // Show generate card if no minutes and generation handler provided
+  if (minutes === undefined && onGenerate !== undefined) {
+    return (
+      <GenerateMinutesCard
+        state={generationState ?? { status: 'idle' }}
+        onGenerate={onGenerate}
+        className={className}
+      />
+    );
+  }
+
+  // Show empty state if no minutes
+  if (minutes === undefined) {
+    return (
+      <div
+        className={`
+          p-8 text-center text-gray-500
+          border border-dashed border-lark-border rounded-lg
+          ${className}
+        `}
+      >
+        <svg
+          className="w-12 h-12 mx-auto mb-3 text-gray-300"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+        <p className="text-sm">No minutes available</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`bg-white rounded-lg border border-lark-border ${className}`}
+      role="region"
+      aria-label="Meeting minutes"
+    >
+      {/* Header */}
+      <header className="p-4 border-b border-lark-border">
+        <div className="flex items-start justify-between gap-4 mb-4">
+          {/* Title and meta */}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 mb-1">
+              <svg
+                className="w-5 h-5 text-lark-primary flex-shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                />
+              </svg>
+              <h2 className="text-lg font-semibold text-lark-text truncate">
+                {minutes.title}
+              </h2>
+            </div>
+            <div className="flex items-center gap-4 text-sm text-gray-500">
+              <span>{minutes.date}</span>
+              <span>{formatDuration(minutes.duration)}</span>
+              <span>{minutes.attendees.length} attendees</span>
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {/* Copy button */}
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="
+                flex items-center gap-2 px-3 py-2
+                text-sm text-gray-600
+                border border-lark-border rounded-lg
+                hover:bg-gray-50 transition-colors
+                focus:outline-none focus:ring-2 focus:ring-lark-primary focus:ring-offset-2
+              "
+              aria-label="Copy as markdown"
+            >
+              {isCopied ? (
+                <>
+                  <svg
+                    className="w-4 h-4 text-green-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                  <span>Copied!</span>
+                </>
+              ) : (
+                <>
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                    />
+                  </svg>
+                  <span>Copy</span>
+                </>
+              )}
+            </button>
+
+            {/* Generate/Regenerate button */}
+            {onGenerate !== undefined && (
+              <GenerateButton
+                state={generationState ?? { status: 'completed' }}
+                onGenerate={onGenerate}
+                onRegenerate={onRegenerate}
+                hasExistingMinutes={true}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Overall summary */}
+        <div className="bg-gray-50 rounded-lg p-4">
+          <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+            Summary
+          </h3>
+          <p className="text-sm text-gray-700 leading-relaxed">
+            {minutes.summary}
+          </p>
+        </div>
+      </header>
+
+      {/* Tabs */}
+      <nav
+        className="border-b border-lark-border"
+        role="tablist"
+        aria-label="Minutes sections"
+      >
+        <div className="flex gap-4 px-4">
+          <TabButton
+            label="Topics"
+            count={minutes.topics.length}
+            isActive={activeTab === 'topics'}
+            onClick={() => setActiveTab('topics')}
+          />
+          <TabButton
+            label="Decisions"
+            count={minutes.decisions.length}
+            isActive={activeTab === 'decisions'}
+            onClick={() => setActiveTab('decisions')}
+          />
+          <TabButton
+            label="Action Items"
+            count={minutes.actionItems.length}
+            isActive={activeTab === 'actions'}
+            onClick={() => setActiveTab('actions')}
+          />
+        </div>
+      </nav>
+
+      {/* Tab content */}
+      <div className="p-4" role="tabpanel" aria-label={`${activeTab} content`}>
+        {activeTab === 'topics' && (
+          <TopicList
+            topics={minutes.topics}
+            onTopicClick={onTopicClick}
+            initialExpanded={true}
+          />
+        )}
+
+        {activeTab === 'decisions' && (
+          <DecisionList
+            decisions={minutes.decisions}
+            topicsMap={topicsMap}
+            onTopicLinkClick={handleTopicLinkClick}
+          />
+        )}
+
+        {activeTab === 'actions' && (
+          <ActionItemList
+            actionItems={minutes.actionItems}
+            showFilters={true}
+            onStatusChange={onActionStatusChange}
+          />
+        )}
+      </div>
+
+      {/* Footer with metadata */}
+      <footer className="px-4 py-3 border-t border-lark-border bg-gray-50 text-xs text-gray-400">
+        <div className="flex items-center justify-between">
+          <span>
+            Generated: {new Date(minutes.metadata.generatedAt).toLocaleString()}
+          </span>
+          <span>
+            Model: {minutes.metadata.model} | Confidence:{' '}
+            {(minutes.metadata.confidence * 100).toFixed(0)}%
+          </span>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+export const MinutesViewer = memo(MinutesViewerInner);

--- a/src/components/minutes/TopicSection.tsx
+++ b/src/components/minutes/TopicSection.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+import { memo, useState, useCallback } from 'react';
+import { AvatarGroup } from '@/components/ui';
+import type { TopicSegment } from '@/types/minutes';
+
+/**
+ * Format time range from start to end time
+ *
+ * @param startTime - Start time in milliseconds
+ * @param endTime - End time in milliseconds
+ * @returns Formatted time range string (e.g., "05:30 - 10:45")
+ */
+function formatTimeRange(startTime: number, endTime: number): string {
+  const formatTime = (ms: number): string => {
+    const totalSeconds = Math.floor(ms / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    const pad = (n: number): string => n.toString().padStart(2, '0');
+
+    if (hours > 0) {
+      return `${hours}:${pad(minutes)}:${pad(seconds)}`;
+    }
+    return `${pad(minutes)}:${pad(seconds)}`;
+  };
+
+  return `${formatTime(startTime)} - ${formatTime(endTime)}`;
+}
+
+/**
+ * Props for TopicSection component
+ */
+export interface TopicSectionProps {
+  /** Topic data to display */
+  readonly topic: TopicSegment;
+  /** Whether the section is initially expanded */
+  readonly initialExpanded?: boolean | undefined;
+  /** Callback when topic is clicked */
+  readonly onTopicClick?: ((topic: TopicSegment) => void) | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * TopicSection component
+ *
+ * @description Displays a single topic/segment from the meeting with
+ *              title, time range, summary, key points, and speakers.
+ * @example
+ * ```tsx
+ * <TopicSection
+ *   topic={{
+ *     id: '1',
+ *     title: 'Q4 Planning',
+ *     startTime: 0,
+ *     endTime: 600000,
+ *     summary: 'Discussed Q4 goals and priorities.',
+ *     keyPoints: ['Budget review', 'Timeline discussion'],
+ *     speakers: [{ id: '1', name: 'John' }],
+ *   }}
+ * />
+ * ```
+ */
+function TopicSectionInner({
+  topic,
+  initialExpanded = true,
+  onTopicClick,
+  className = '',
+}: TopicSectionProps): JSX.Element {
+  const [isExpanded, setIsExpanded] = useState(initialExpanded);
+
+  const handleToggle = useCallback(() => {
+    setIsExpanded((prev) => !prev);
+  }, []);
+
+  const handleClick = useCallback(() => {
+    onTopicClick?.(topic);
+  }, [onTopicClick, topic]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        handleToggle();
+      }
+    },
+    [handleToggle]
+  );
+
+  const timeRange = formatTimeRange(topic.startTime, topic.endTime);
+  const isClickable = onTopicClick !== undefined;
+
+  return (
+    <article
+      className={`
+        border border-lark-border rounded-lg bg-white
+        transition-shadow duration-200
+        hover:shadow-sm
+        ${className}
+      `}
+      aria-labelledby={`topic-title-${topic.id}`}
+    >
+      {/* Header */}
+      <header
+        className={`
+          flex items-center justify-between gap-4 p-4
+          ${isExpanded ? 'border-b border-gray-100' : ''}
+          cursor-pointer select-none
+        `}
+        onClick={handleToggle}
+        onKeyDown={handleKeyDown}
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
+        aria-controls={`topic-content-${topic.id}`}
+      >
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          {/* Expand/Collapse icon */}
+          <button
+            type="button"
+            className="flex-shrink-0 p-1 rounded hover:bg-gray-100 transition-colors"
+            aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
+            tabIndex={-1}
+          >
+            <svg
+              className={`w-4 h-4 text-gray-500 transition-transform duration-200 ${
+                isExpanded ? 'rotate-90' : ''
+              }`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+          </button>
+
+          {/* Title */}
+          <h3
+            id={`topic-title-${topic.id}`}
+            className="text-base font-medium text-lark-text truncate"
+          >
+            {topic.title}
+          </h3>
+        </div>
+
+        {/* Time range */}
+        <time
+          className="flex-shrink-0 text-sm text-gray-500 font-mono"
+          aria-label={`Time range: ${timeRange}`}
+        >
+          {timeRange}
+        </time>
+      </header>
+
+      {/* Content */}
+      {isExpanded && (
+        <div
+          id={`topic-content-${topic.id}`}
+          className="p-4"
+          role="region"
+          aria-labelledby={`topic-title-${topic.id}`}
+        >
+          {/* Summary */}
+          <div className="mb-4">
+            <p className="text-sm text-gray-700 leading-relaxed">
+              {topic.summary}
+            </p>
+          </div>
+
+          {/* Key Points */}
+          {topic.keyPoints.length > 0 && (
+            <div className="mb-4">
+              <h4 className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+                Key Points
+              </h4>
+              <ul
+                className="space-y-1.5 text-sm text-gray-700"
+                aria-label="Key points"
+              >
+                {topic.keyPoints.map((point, index) => (
+                  <li key={index} className="flex items-start gap-2">
+                    <span
+                      className="flex-shrink-0 w-1.5 h-1.5 rounded-full bg-lark-primary mt-2"
+                      aria-hidden="true"
+                    />
+                    <span>{point}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Speakers */}
+          {topic.speakers.length > 0 && (
+            <div className="pt-3 border-t border-gray-100">
+              <div className="flex items-center gap-3">
+                <AvatarGroup
+                  avatars={topic.speakers.map((speaker) => ({
+                    name: speaker.name,
+                  }))}
+                  max={5}
+                  size="sm"
+                />
+                <span className="text-xs text-gray-500">
+                  {topic.speakers.length}
+                  {topic.speakers.length === 1 ? ' speaker' : ' speakers'}
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Click to navigate (optional) */}
+          {isClickable && (
+            <div className="mt-3 pt-3 border-t border-gray-100">
+              <button
+                type="button"
+                onClick={handleClick}
+                className="
+                  text-sm text-lark-primary hover:text-blue-700
+                  flex items-center gap-1
+                  focus:outline-none focus:underline
+                "
+              >
+                <span>View in transcript</span>
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M14 5l7 7m0 0l-7 7m7-7H3"
+                  />
+                </svg>
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </article>
+  );
+}
+
+export const TopicSection = memo(TopicSectionInner);
+
+/**
+ * Props for TopicList component
+ */
+export interface TopicListProps {
+  /** List of topics to display */
+  readonly topics: readonly TopicSegment[];
+  /** Callback when a topic is clicked */
+  readonly onTopicClick?: ((topic: TopicSegment) => void) | undefined;
+  /** Whether topics are initially expanded */
+  readonly initialExpanded?: boolean | undefined;
+  /** Custom class name */
+  readonly className?: string | undefined;
+}
+
+/**
+ * TopicList component
+ *
+ * @description Displays a list of topics from the meeting
+ * @example
+ * ```tsx
+ * <TopicList topics={minutes.topics} onTopicClick={handleTopicClick} />
+ * ```
+ */
+export function TopicList({
+  topics,
+  onTopicClick,
+  initialExpanded = true,
+  className = '',
+}: TopicListProps): JSX.Element {
+  if (topics.length === 0) {
+    return (
+      <div
+        className={`
+          p-8 text-center text-gray-500
+          border border-dashed border-lark-border rounded-lg
+          ${className}
+        `}
+      >
+        <svg
+          className="w-12 h-12 mx-auto mb-3 text-gray-300"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+          />
+        </svg>
+        <p className="text-sm">No topics found</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`space-y-4 ${className}`}
+      role="list"
+      aria-label="Meeting topics"
+    >
+      {topics.map((topic) => (
+        <div key={topic.id} role="listitem">
+          <TopicSection
+            topic={topic}
+            onTopicClick={onTopicClick}
+            initialExpanded={initialExpanded}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/minutes/index.ts
+++ b/src/components/minutes/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Minutes UI Components
+ *
+ * @description Components for displaying AI-generated meeting minutes
+ *              including topics, decisions, action items, and generation controls.
+ * @module components/minutes
+ */
+
+// MinutesViewer - Main component
+export { MinutesViewer } from './MinutesViewer';
+export type { MinutesViewerProps, MinutesTab } from './MinutesViewer';
+
+// TopicSection - Topic/segment display
+export { TopicSection, TopicList } from './TopicSection';
+export type { TopicSectionProps, TopicListProps } from './TopicSection';
+
+// DecisionList - Decision items display
+export { DecisionItemCard, DecisionList } from './DecisionList';
+export type { DecisionItemCardProps, DecisionListProps } from './DecisionList';
+
+// ActionItemList - Action items display with filtering
+export {
+  ActionItemCard,
+  ActionItemFilters,
+  ActionItemList,
+} from './ActionItemList';
+export type {
+  ActionItemCardProps,
+  ActionItemFiltersProps,
+  ActionItemFilterOptions,
+  ActionItemListProps,
+} from './ActionItemList';
+
+// GenerateButton - Generation controls
+export { GenerateButton, GenerateMinutesCard } from './GenerateButton';
+export type {
+  GenerateButtonProps,
+  GenerateMinutesCardProps,
+  GenerationState,
+  GenerationStatus,
+} from './GenerateButton';
+
+// MinutesSkeleton - Loading states
+export { MinutesSkeleton, MinutesContentSkeleton } from './MinutesSkeleton';
+export type {
+  MinutesSkeletonProps,
+  MinutesContentSkeletonProps,
+} from './MinutesSkeleton';

--- a/src/lib/claude/__tests__/client.test.ts
+++ b/src/lib/claude/__tests__/client.test.ts
@@ -1,0 +1,556 @@
+/**
+ * ClaudeClient Tests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
+
+import { ClaudeClient } from '../client.js';
+import { ClaudeApiError, ClaudeParseError, DEFAULT_MODEL, DEFAULT_MAX_TOKENS } from '../types.js';
+
+// Anthropic SDKをモック
+vi.mock('@anthropic-ai/sdk', () => {
+  const mockCreate = vi.fn();
+
+  class MockAnthropic {
+    messages = {
+      create: mockCreate,
+    };
+  }
+
+  // APIErrorクラス（テスト用）- モック内で定義する必要がある
+  class MockAPIError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.name = 'APIError';
+    }
+  }
+
+  return {
+    default: MockAnthropic,
+    APIError: MockAPIError,
+  };
+});
+
+// テスト用APIErrorクラスを取得するヘルパー
+async function createMockAPIError(status: number, message: string): Promise<Error> {
+  const Anthropic = await import('@anthropic-ai/sdk');
+  // モックしたAPIErrorは引数が2つ（status, message）
+  type MockedAPIErrorConstructor = new (status: number, message: string) => Error;
+  const MockedAPIError = Anthropic.APIError as unknown as MockedAPIErrorConstructor;
+  return new MockedAPIError(status, message);
+}
+
+// モック関数を取得
+async function getMockCreate(): Promise<ReturnType<typeof vi.fn>> {
+  const Anthropic = await import('@anthropic-ai/sdk');
+  const instance = new Anthropic.default({ apiKey: 'test-key' });
+  return instance.messages.create as ReturnType<typeof vi.fn>;
+}
+
+describe('ClaudeClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should create client with valid API key', () => {
+      const client = new ClaudeClient('test-api-key');
+      expect(client).toBeInstanceOf(ClaudeClient);
+    });
+
+    it('should throw error with empty API key', () => {
+      expect(() => new ClaudeClient('')).toThrow(ClaudeApiError);
+      expect(() => new ClaudeClient('')).toThrow('API key is required');
+    });
+
+    it('should throw error with whitespace-only API key', () => {
+      expect(() => new ClaudeClient('   ')).toThrow(ClaudeApiError);
+    });
+
+    it('should accept custom model and maxTokens options', () => {
+      const client = new ClaudeClient('test-api-key', {
+        model: 'claude-opus-4-20250514',
+        maxTokens: 8000,
+      });
+      expect(client).toBeInstanceOf(ClaudeClient);
+    });
+  });
+
+  describe('sendMessage', () => {
+    it('should send message and return text response', async () => {
+      const mockCreate = await getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello! How can I help you?' }],
+        model: DEFAULT_MODEL,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 20 },
+      });
+
+      const client = new ClaudeClient('test-api-key');
+      const response = await client.sendMessage([
+        { role: 'user', content: 'Hello!' },
+      ]);
+
+      expect(response).toBe('Hello! How can I help you?');
+      expect(mockCreate).toHaveBeenCalledWith({
+        model: DEFAULT_MODEL,
+        max_tokens: DEFAULT_MAX_TOKENS,
+        messages: [{ role: 'user', content: 'Hello!' }],
+      });
+    });
+
+    it('should include system prompt when provided', async () => {
+      const mockCreate = await getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Response' }],
+        model: DEFAULT_MODEL,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 5 },
+      });
+
+      const client = new ClaudeClient('test-api-key');
+      await client.sendMessage(
+        [{ role: 'user', content: 'Test' }],
+        { system: 'You are a helpful assistant.' }
+      );
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        model: DEFAULT_MODEL,
+        max_tokens: DEFAULT_MAX_TOKENS,
+        messages: [{ role: 'user', content: 'Test' }],
+        system: 'You are a helpful assistant.',
+      });
+    });
+
+    it('should use custom maxTokens when provided', async () => {
+      const mockCreate = await getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Response' }],
+        model: DEFAULT_MODEL,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 5 },
+      });
+
+      const client = new ClaudeClient('test-api-key');
+      await client.sendMessage(
+        [{ role: 'user', content: 'Test' }],
+        { maxTokens: 2000 }
+      );
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        model: DEFAULT_MODEL,
+        max_tokens: 2000,
+        messages: [{ role: 'user', content: 'Test' }],
+      });
+    });
+
+    it('should throw error for empty messages array', async () => {
+      const client = new ClaudeClient('test-api-key');
+
+      await expect(client.sendMessage([])).rejects.toThrow(ClaudeApiError);
+      await expect(client.sendMessage([])).rejects.toThrow(
+        'At least one message is required'
+      );
+    });
+
+    it('should throw ClaudeApiError when API returns error', async () => {
+      const mockCreate = await getMockCreate();
+      const apiError = await createMockAPIError(429, 'Rate limit exceeded');
+      mockCreate.mockRejectedValueOnce(apiError);
+
+      const client = new ClaudeClient('test-api-key');
+
+      await expect(
+        client.sendMessage([{ role: 'user', content: 'Hello' }])
+      ).rejects.toThrow(ClaudeApiError);
+    });
+
+    it('should throw ClaudeApiError when no text content in response', async () => {
+      const mockCreate = await getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: DEFAULT_MODEL,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 10, output_tokens: 0 },
+      });
+
+      const client = new ClaudeClient('test-api-key');
+
+      await expect(
+        client.sendMessage([{ role: 'user', content: 'Hello' }])
+      ).rejects.toThrow('No text content in response');
+    });
+
+    it('should handle multi-turn conversations', async () => {
+      const mockCreate = await getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Paris' }],
+        model: DEFAULT_MODEL,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 30, output_tokens: 5 },
+      });
+
+      const client = new ClaudeClient('test-api-key');
+      const response = await client.sendMessage([
+        { role: 'user', content: 'What is the capital of France?' },
+        { role: 'assistant', content: 'The capital of France is Paris.' },
+        { role: 'user', content: 'Just the city name please.' },
+      ]);
+
+      expect(response).toBe('Paris');
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: [
+            { role: 'user', content: 'What is the capital of France?' },
+            { role: 'assistant', content: 'The capital of France is Paris.' },
+            { role: 'user', content: 'Just the city name please.' },
+          ],
+        })
+      );
+    });
+  });
+
+  describe('generateStructuredOutput', () => {
+    const personSchema = z.object({
+      name: z.string(),
+      age: z.number(),
+      email: z.string().email().optional(),
+    });
+
+    it('should parse valid JSON response', async () => {
+      const mockCreate = await getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: '{"name": "John", "age": 30}' }],
+        model: DEFAULT_MODEL,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 50, output_tokens: 20 },
+      });
+
+      const client = new ClaudeClient('test-api-key');
+      const result = await client.generateStructuredOutput(
+        [{ role: 'user', content: 'Generate a person' }],
+        personSchema
+      );
+
+      expect(result).toEqual({ name: 'John', age: 30 });
+    });
+
+    it('should extract JSON from code block', async () => {
+      const mockCreate = await getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Here is the JSON:\n```json\n{"name": "Jane", "age": 25}\n```',
+          },
+        ],
+        model: DEFAULT_MODEL,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 50, output_tokens: 30 },
+      });
+
+      const client = new ClaudeClient('test-api-key');
+      const result = await client.generateStructuredOutput(
+        [{ role: 'user', content: 'Generate a person' }],
+        personSchema
+      );
+
+      expect(result).toEqual({ name: 'Jane', age: 25 });
+    });
+
+    it('should extract JSON object from mixed text', async () => {
+      const mockCreate = await getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'Sure! Here is the data: {"name": "Bob", "age": 35} Hope this helps!',
+          },
+        ],
+        model: DEFAULT_MODEL,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 50, output_tokens: 40 },
+      });
+
+      const client = new ClaudeClient('test-api-key');
+      const result = await client.generateStructuredOutput(
+        [{ role: 'user', content: 'Generate a person' }],
+        personSchema
+      );
+
+      expect(result).toEqual({ name: 'Bob', age: 35 });
+    });
+
+    it('should parse array responses', async () => {
+      const mockCreate = await getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: '["apple", "banana", "cherry"]' }],
+        model: DEFAULT_MODEL,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 30, output_tokens: 15 },
+      });
+
+      const arraySchema = z.array(z.string());
+      const client = new ClaudeClient('test-api-key');
+      const result = await client.generateStructuredOutput(
+        [{ role: 'user', content: 'List fruits' }],
+        arraySchema
+      );
+
+      expect(result).toEqual(['apple', 'banana', 'cherry']);
+    });
+
+    it('should throw ClaudeParseError for invalid JSON', async () => {
+      const mockCreate = await getMockCreate();
+      // 2回呼ばれる（リトライ1回）
+      mockCreate
+        .mockResolvedValueOnce({
+          id: 'msg_123',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'This is not valid JSON at all' }],
+          model: DEFAULT_MODEL,
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 50, output_tokens: 10 },
+        })
+        .mockResolvedValueOnce({
+          id: 'msg_124',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Still not JSON' }],
+          model: DEFAULT_MODEL,
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 50, output_tokens: 10 },
+        });
+
+      const client = new ClaudeClient('test-api-key');
+
+      await expect(
+        client.generateStructuredOutput(
+          [{ role: 'user', content: 'Generate something' }],
+          personSchema
+        )
+      ).rejects.toThrow(ClaudeParseError);
+    });
+
+    it('should throw ClaudeParseError for schema validation failure', async () => {
+      const mockCreate = await getMockCreate();
+      mockCreate
+        .mockResolvedValueOnce({
+          id: 'msg_123',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: '{"name": "John"}' }], // missing required 'age'
+          model: DEFAULT_MODEL,
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 50, output_tokens: 15 },
+        })
+        .mockResolvedValueOnce({
+          id: 'msg_124',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: '{"name": "John"}' }],
+          model: DEFAULT_MODEL,
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 50, output_tokens: 15 },
+        });
+
+      const client = new ClaudeClient('test-api-key');
+
+      await expect(
+        client.generateStructuredOutput(
+          [{ role: 'user', content: 'Generate a person' }],
+          personSchema
+        )
+      ).rejects.toThrow(ClaudeParseError);
+    });
+
+    it('should retry on parse failure', async () => {
+      const mockCreate = await getMockCreate();
+      mockCreate
+        .mockResolvedValueOnce({
+          id: 'msg_123',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'invalid' }],
+          model: DEFAULT_MODEL,
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 50, output_tokens: 5 },
+        })
+        .mockResolvedValueOnce({
+          id: 'msg_124',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: '{"name": "Jane", "age": 28}' }],
+          model: DEFAULT_MODEL,
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 50, output_tokens: 20 },
+        });
+
+      const client = new ClaudeClient('test-api-key');
+      const result = await client.generateStructuredOutput(
+        [{ role: 'user', content: 'Generate a person' }],
+        personSchema,
+        { retryCount: 1 }
+      );
+
+      expect(result).toEqual({ name: 'Jane', age: 28 });
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not retry on API error', async () => {
+      const mockCreate = await getMockCreate();
+      const apiError = await createMockAPIError(500, 'Server error');
+      mockCreate.mockRejectedValueOnce(apiError);
+
+      const client = new ClaudeClient('test-api-key');
+
+      await expect(
+        client.generateStructuredOutput(
+          [{ role: 'user', content: 'Generate a person' }],
+          personSchema,
+          { retryCount: 3 }
+        )
+      ).rejects.toThrow(ClaudeApiError);
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should include base system prompt with JSON instructions', async () => {
+      const mockCreate = await getMockCreate();
+      mockCreate.mockResolvedValueOnce({
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'text', text: '{"name": "Test", "age": 20}' }],
+        model: DEFAULT_MODEL,
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: { input_tokens: 80, output_tokens: 20 },
+      });
+
+      const client = new ClaudeClient('test-api-key');
+      await client.generateStructuredOutput(
+        [{ role: 'user', content: 'Generate a person' }],
+        personSchema,
+        { system: 'Generate realistic data.' }
+      );
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          system: expect.stringContaining('Generate realistic data.'),
+        })
+      );
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          system: expect.stringContaining('valid JSON'),
+        })
+      );
+    });
+  });
+});
+
+describe('Error classes', () => {
+  describe('ClaudeApiError', () => {
+    it('should create error with message only', () => {
+      const error = new ClaudeApiError('Test error');
+      expect(error.message).toBe('Test error');
+      expect(error.name).toBe('ClaudeApiError');
+      expect(error.statusCode).toBeUndefined();
+      expect(error.cause).toBeUndefined();
+    });
+
+    it('should create error with status code', () => {
+      const error = new ClaudeApiError('Rate limited', 429);
+      expect(error.statusCode).toBe(429);
+    });
+
+    it('should create error with cause', () => {
+      const cause = new Error('Original error');
+      const error = new ClaudeApiError('Wrapped error', 500, cause);
+      expect(error.cause).toBe(cause);
+    });
+
+    it('should be instanceof Error', () => {
+      const error = new ClaudeApiError('Test');
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(ClaudeApiError);
+    });
+  });
+
+  describe('ClaudeParseError', () => {
+    it('should create error with message only', () => {
+      const error = new ClaudeParseError('Parse failed');
+      expect(error.message).toBe('Parse failed');
+      expect(error.name).toBe('ClaudeParseError');
+      expect(error.rawContent).toBeUndefined();
+      expect(error.cause).toBeUndefined();
+    });
+
+    it('should create error with raw content', () => {
+      const error = new ClaudeParseError('Invalid JSON', '{ invalid }');
+      expect(error.rawContent).toBe('{ invalid }');
+    });
+
+    it('should create error with cause', () => {
+      const cause = new SyntaxError('Unexpected token');
+      const error = new ClaudeParseError('Parse failed', '{}', cause);
+      expect(error.cause).toBe(cause);
+    });
+
+    it('should be instanceof Error', () => {
+      const error = new ClaudeParseError('Test');
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(ClaudeParseError);
+    });
+  });
+});

--- a/src/lib/claude/__tests__/prompts.test.ts
+++ b/src/lib/claude/__tests__/prompts.test.ts
@@ -1,0 +1,908 @@
+/**
+ * Prompt Templates Tests
+ *
+ * 議事録生成プロンプトテンプレートのテスト
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Minutes Generation
+import {
+  MINUTES_GENERATION_SYSTEM_PROMPT,
+  getSystemPrompt,
+  buildMinutesGenerationPrompt,
+  minutesOutputSchema,
+  MinutesOutputSpeakerSchema,
+  MinutesOutputTopicSchema,
+  MinutesOutputDecisionSchema,
+  MinutesOutputActionItemSchema,
+  validateMinutesGenerationInput,
+  validateMinutesOutput,
+  type MinutesGenerationInput,
+} from '../prompts/minutes-generation.js';
+
+// Templates
+import {
+  replaceTemplateVariables,
+  extractTemplateVariables,
+  validateTemplateVariables,
+  buildStructuredPrompt,
+  JSON_OUTPUT_INSTRUCTION_JA,
+  JSON_OUTPUT_INSTRUCTION_EN,
+  JAPANESE_MEETING_INSTRUCTION,
+  getJsonOutputInstruction,
+  trimText,
+  formatList,
+  estimateTokenCount,
+  splitTranscriptByTokens,
+  formatDate,
+  type TemplateVariables,
+  type StructuredPrompt,
+} from '../prompts/templates.js';
+
+// =============================================================================
+// Minutes Generation Tests
+// =============================================================================
+
+describe('Minutes Generation Prompts', () => {
+  describe('MINUTES_GENERATION_SYSTEM_PROMPT', () => {
+    it('should be a non-empty string', () => {
+      expect(MINUTES_GENERATION_SYSTEM_PROMPT).toBeDefined();
+      expect(typeof MINUTES_GENERATION_SYSTEM_PROMPT).toBe('string');
+      expect(MINUTES_GENERATION_SYSTEM_PROMPT.length).toBeGreaterThan(0);
+    });
+
+    it('should contain key instructions', () => {
+      expect(MINUTES_GENERATION_SYSTEM_PROMPT).toContain('議事録');
+      expect(MINUTES_GENERATION_SYSTEM_PROMPT).toContain('JSON');
+    });
+  });
+
+  describe('getSystemPrompt', () => {
+    it('should return Japanese prompt by default', () => {
+      const prompt = getSystemPrompt();
+      expect(prompt).toContain('議事録');
+    });
+
+    it('should return Japanese prompt when ja is specified', () => {
+      const prompt = getSystemPrompt('ja');
+      expect(prompt).toContain('議事録');
+      expect(prompt).toContain('JSON形式');
+    });
+
+    it('should return English prompt when en is specified', () => {
+      const prompt = getSystemPrompt('en');
+      expect(prompt).toContain('meeting minutes');
+      expect(prompt).toContain('JSON');
+    });
+  });
+
+  describe('buildMinutesGenerationPrompt', () => {
+    const validInput: MinutesGenerationInput = {
+      transcript: '田中: おはようございます。本日の議題について説明します。',
+      meetingTitle: '週次定例会議',
+      meetingDate: '2025-01-22',
+      attendees: ['田中', '鈴木', '佐藤'],
+      language: 'ja',
+    };
+
+    it('should build prompt with all required fields', () => {
+      const prompt = buildMinutesGenerationPrompt(validInput);
+
+      expect(prompt).toContain('週次定例会議');
+      expect(prompt).toContain('2025-01-22');
+      expect(prompt).toContain('田中, 鈴木, 佐藤');
+      expect(prompt).toContain('田中: おはようございます');
+    });
+
+    it('should use Japanese template by default', () => {
+      const input: Omit<MinutesGenerationInput, 'language'> = {
+        transcript: validInput.transcript,
+        meetingTitle: validInput.meetingTitle,
+        meetingDate: validInput.meetingDate,
+        attendees: validInput.attendees,
+      };
+      const prompt = buildMinutesGenerationPrompt(input);
+
+      expect(prompt).toContain('出力要件');
+      expect(prompt).toContain('全体要約');
+      expect(prompt).toContain('話題セグメント');
+    });
+
+    it('should use English template when specified', () => {
+      const input: MinutesGenerationInput = {
+        ...validInput,
+        language: 'en',
+      };
+      const prompt = buildMinutesGenerationPrompt(input);
+
+      expect(prompt).toContain('Output Requirements');
+      expect(prompt).toContain('Overall Summary');
+      expect(prompt).toContain('Topic Segments');
+    });
+
+    it('should handle empty attendees array', () => {
+      const input: MinutesGenerationInput = {
+        ...validInput,
+        attendees: [],
+      };
+      const prompt = buildMinutesGenerationPrompt(input);
+
+      expect(prompt).toContain('(Not specified)');
+    });
+
+    it('should throw error for empty transcript', () => {
+      const input: MinutesGenerationInput = {
+        ...validInput,
+        transcript: '',
+      };
+
+      expect(() => buildMinutesGenerationPrompt(input)).toThrow(
+        'Transcript is required and cannot be empty'
+      );
+    });
+
+    it('should throw error for whitespace-only transcript', () => {
+      const input: MinutesGenerationInput = {
+        ...validInput,
+        transcript: '   ',
+      };
+
+      expect(() => buildMinutesGenerationPrompt(input)).toThrow(
+        'Transcript is required and cannot be empty'
+      );
+    });
+
+    it('should throw error for empty meeting title', () => {
+      const input: MinutesGenerationInput = {
+        ...validInput,
+        meetingTitle: '',
+      };
+
+      expect(() => buildMinutesGenerationPrompt(input)).toThrow(
+        'Meeting title is required and cannot be empty'
+      );
+    });
+
+    it('should throw error for empty meeting date', () => {
+      const input: MinutesGenerationInput = {
+        ...validInput,
+        meetingDate: '',
+      };
+
+      expect(() => buildMinutesGenerationPrompt(input)).toThrow(
+        'Meeting date is required and cannot be empty'
+      );
+    });
+
+    it('should include decision extraction keywords', () => {
+      const prompt = buildMinutesGenerationPrompt(validInput);
+
+      expect(prompt).toMatch(/決定|承認|合意/);
+    });
+
+    it('should include action item extraction keywords', () => {
+      const prompt = buildMinutesGenerationPrompt(validInput);
+
+      expect(prompt).toMatch(/やる|対応|確認|作成/);
+    });
+
+    it('should contain schema field descriptions', () => {
+      const prompt = buildMinutesGenerationPrompt(validInput);
+
+      expect(prompt).toContain('summary');
+      expect(prompt).toContain('topics');
+      expect(prompt).toContain('decisions');
+      expect(prompt).toContain('actionItems');
+    });
+  });
+
+  describe('validateMinutesGenerationInput', () => {
+    it('should validate valid input', () => {
+      const input = {
+        transcript: 'Test transcript',
+        meetingTitle: 'Test Meeting',
+        meetingDate: '2025-01-22',
+        attendees: ['Person 1', 'Person 2'],
+      };
+
+      const result = validateMinutesGenerationInput(input);
+
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.data.transcript).toBe('Test transcript');
+        expect(result.data.language).toBe('ja'); // default
+      }
+    });
+
+    it('should validate input with optional language', () => {
+      const input = {
+        transcript: 'Test transcript',
+        meetingTitle: 'Test Meeting',
+        meetingDate: '2025-01-22',
+        attendees: [],
+        language: 'en',
+      };
+
+      const result = validateMinutesGenerationInput(input);
+
+      expect(result.valid).toBe(true);
+      if (result.valid) {
+        expect(result.data.language).toBe('en');
+      }
+    });
+
+    it('should reject non-object input', () => {
+      const result = validateMinutesGenerationInput('not an object');
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors).toContain('Input must be an object');
+      }
+    });
+
+    it('should reject null input', () => {
+      const result = validateMinutesGenerationInput(null);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it('should reject missing transcript', () => {
+      const input = {
+        meetingTitle: 'Test Meeting',
+        meetingDate: '2025-01-22',
+        attendees: [],
+      };
+
+      const result = validateMinutesGenerationInput(input);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.includes('transcript'))).toBe(true);
+      }
+    });
+
+    it('should reject invalid date format', () => {
+      const input = {
+        transcript: 'Test',
+        meetingTitle: 'Test Meeting',
+        meetingDate: 'January 22, 2025',
+        attendees: [],
+      };
+
+      const result = validateMinutesGenerationInput(input);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.includes('meetingDate'))).toBe(true);
+      }
+    });
+
+    it('should reject invalid language', () => {
+      const input = {
+        transcript: 'Test',
+        meetingTitle: 'Test Meeting',
+        meetingDate: '2025-01-22',
+        attendees: [],
+        language: 'fr',
+      };
+
+      const result = validateMinutesGenerationInput(input);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.includes('language'))).toBe(true);
+      }
+    });
+
+    it('should reject non-string attendees', () => {
+      const input = {
+        transcript: 'Test',
+        meetingTitle: 'Test Meeting',
+        meetingDate: '2025-01-22',
+        attendees: [1, 2, 3],
+      };
+
+      const result = validateMinutesGenerationInput(input);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.includes('attendees'))).toBe(true);
+      }
+    });
+  });
+});
+
+// =============================================================================
+// Output Schema Tests
+// =============================================================================
+
+describe('Output Schema', () => {
+  describe('MinutesOutputSpeakerSchema', () => {
+    it('should validate valid speaker', () => {
+      const speaker = { name: 'John Doe' };
+      const result = MinutesOutputSpeakerSchema.safeParse(speaker);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate speaker with larkUserId', () => {
+      const speaker = { name: 'John Doe', larkUserId: 'user123' };
+      const result = MinutesOutputSpeakerSchema.safeParse(speaker);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject empty name', () => {
+      const speaker = { name: '' };
+      const result = MinutesOutputSpeakerSchema.safeParse(speaker);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('MinutesOutputTopicSchema', () => {
+    it('should validate valid topic', () => {
+      const topic = {
+        title: 'Budget Discussion',
+        startTime: 0,
+        endTime: 300000,
+        summary: 'Discussed Q1 budget',
+        keyPoints: ['Point 1', 'Point 2'],
+      };
+      const result = MinutesOutputTopicSchema.safeParse(topic);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate topic with speakers', () => {
+      const topic = {
+        title: 'Budget Discussion',
+        startTime: 0,
+        endTime: 300000,
+        summary: 'Discussed Q1 budget',
+        keyPoints: [],
+        speakers: [{ name: 'John' }],
+      };
+      const result = MinutesOutputTopicSchema.safeParse(topic);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject negative startTime', () => {
+      const topic = {
+        title: 'Topic',
+        startTime: -1,
+        endTime: 100,
+        summary: '',
+        keyPoints: [],
+      };
+      const result = MinutesOutputTopicSchema.safeParse(topic);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('MinutesOutputDecisionSchema', () => {
+    it('should validate valid decision', () => {
+      const decision = {
+        content: 'Approved budget increase',
+        context: 'Based on Q4 performance',
+        decidedAt: 150000,
+      };
+      const result = MinutesOutputDecisionSchema.safeParse(decision);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject empty content', () => {
+      const decision = {
+        content: '',
+        context: 'Some context',
+        decidedAt: 0,
+      };
+      const result = MinutesOutputDecisionSchema.safeParse(decision);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('MinutesOutputActionItemSchema', () => {
+    it('should validate valid action item', () => {
+      const item = {
+        content: 'Review document',
+        priority: 'high',
+      };
+      const result = MinutesOutputActionItemSchema.safeParse(item);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate action item with all optional fields', () => {
+      const item = {
+        content: 'Review document',
+        assignee: { name: 'John' },
+        dueDate: '2025-01-30',
+        priority: 'medium',
+      };
+      const result = MinutesOutputActionItemSchema.safeParse(item);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject invalid priority', () => {
+      const item = {
+        content: 'Task',
+        priority: 'urgent',
+      };
+      const result = MinutesOutputActionItemSchema.safeParse(item);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject invalid date format', () => {
+      const item = {
+        content: 'Task',
+        dueDate: 'Jan 30, 2025',
+        priority: 'low',
+      };
+      const result = MinutesOutputActionItemSchema.safeParse(item);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('minutesOutputSchema', () => {
+    it('should validate complete valid output', () => {
+      const output = {
+        summary: 'Meeting covered budget and timeline',
+        topics: [
+          {
+            title: 'Budget',
+            startTime: 0,
+            endTime: 300000,
+            summary: 'Budget discussion',
+            keyPoints: ['Increase approved'],
+          },
+        ],
+        decisions: [
+          {
+            content: 'Budget approved',
+            context: 'After review',
+            decidedAt: 250000,
+          },
+        ],
+        actionItems: [
+          {
+            content: 'Update documents',
+            priority: 'high',
+          },
+        ],
+      };
+      const result = minutesOutputSchema.safeParse(output);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate output with empty arrays', () => {
+      const output = {
+        summary: 'Brief meeting',
+        topics: [],
+        decisions: [],
+        actionItems: [],
+      };
+      const result = minutesOutputSchema.safeParse(output);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate output with optional attendees', () => {
+      const output = {
+        summary: 'Meeting summary',
+        topics: [],
+        decisions: [],
+        actionItems: [],
+        attendees: [{ name: 'John' }, { name: 'Jane' }],
+      };
+      const result = minutesOutputSchema.safeParse(output);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject empty summary', () => {
+      const output = {
+        summary: '',
+        topics: [],
+        decisions: [],
+        actionItems: [],
+      };
+      const result = minutesOutputSchema.safeParse(output);
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject missing required fields', () => {
+      const output = {
+        summary: 'Summary only',
+      };
+      const result = minutesOutputSchema.safeParse(output);
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('validateMinutesOutput', () => {
+    it('should return success for valid output', () => {
+      const output = {
+        summary: 'Test summary',
+        topics: [],
+        decisions: [],
+        actionItems: [],
+      };
+      const result = validateMinutesOutput(output);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should return error for invalid output', () => {
+      const output = { invalid: 'data' };
+      const result = validateMinutesOutput(output);
+
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+// =============================================================================
+// Template Utilities Tests
+// =============================================================================
+
+describe('Template Utilities', () => {
+  describe('replaceTemplateVariables', () => {
+    it('should replace simple variables', () => {
+      const template = 'Hello, {{name}}!';
+      const variables: TemplateVariables = { name: 'World' };
+      const result = replaceTemplateVariables(template, variables);
+
+      expect(result).toBe('Hello, World!');
+    });
+
+    it('should replace multiple variables', () => {
+      const template = '{{greeting}}, {{name}}! Today is {{day}}.';
+      const variables: TemplateVariables = {
+        greeting: 'Hello',
+        name: 'John',
+        day: 'Monday',
+      };
+      const result = replaceTemplateVariables(template, variables);
+
+      expect(result).toBe('Hello, John! Today is Monday.');
+    });
+
+    it('should handle array variables', () => {
+      const template = 'Attendees: {{attendees}}';
+      const variables: TemplateVariables = {
+        attendees: ['Alice', 'Bob', 'Charlie'],
+      };
+      const result = replaceTemplateVariables(template, variables);
+
+      expect(result).toBe('Attendees: Alice, Bob, Charlie');
+    });
+
+    it('should use custom array separator', () => {
+      const template = 'Items: {{items}}';
+      const variables: TemplateVariables = { items: ['A', 'B', 'C'] };
+      const result = replaceTemplateVariables(template, variables, {
+        arraySeparator: ' | ',
+      });
+
+      expect(result).toBe('Items: A | B | C');
+    });
+
+    it('should keep missing variables by default', () => {
+      const template = 'Hello, {{name}}! Your role is {{role}}.';
+      const variables: TemplateVariables = { name: 'John' };
+      const result = replaceTemplateVariables(template, variables);
+
+      expect(result).toBe('Hello, John! Your role is {{role}}.');
+    });
+
+    it('should remove missing variables when option is set', () => {
+      const template = 'Hello, {{name}}! Your role is {{role}}.';
+      const variables: TemplateVariables = { name: 'John' };
+      const result = replaceTemplateVariables(template, variables, {
+        missingVariableHandling: 'remove',
+      });
+
+      expect(result).toBe('Hello, John! Your role is .');
+    });
+
+    it('should throw error for missing variables when option is set', () => {
+      const template = 'Hello, {{name}}! Your role is {{role}}.';
+      const variables: TemplateVariables = { name: 'John' };
+
+      expect(() =>
+        replaceTemplateVariables(template, variables, {
+          missingVariableHandling: 'error',
+        })
+      ).toThrow("Template variable 'role' is not defined");
+    });
+
+    it('should handle number variables', () => {
+      const template = 'Count: {{count}}';
+      const variables: TemplateVariables = { count: 42 };
+      const result = replaceTemplateVariables(template, variables);
+
+      expect(result).toBe('Count: 42');
+    });
+
+    it('should handle boolean variables', () => {
+      const template = 'Active: {{active}}';
+      const variables: TemplateVariables = { active: true };
+      const result = replaceTemplateVariables(template, variables);
+
+      expect(result).toBe('Active: true');
+    });
+  });
+
+  describe('extractTemplateVariables', () => {
+    it('should extract single variable', () => {
+      const template = 'Hello, {{name}}!';
+      const variables = extractTemplateVariables(template);
+
+      expect(variables).toEqual(['name']);
+    });
+
+    it('should extract multiple variables', () => {
+      const template = '{{greeting}}, {{name}}! Today is {{day}}.';
+      const variables = extractTemplateVariables(template);
+
+      expect(variables).toContain('greeting');
+      expect(variables).toContain('name');
+      expect(variables).toContain('day');
+      expect(variables).toHaveLength(3);
+    });
+
+    it('should return unique variables only', () => {
+      const template = '{{name}} said to {{name}}: Hello {{name}}!';
+      const variables = extractTemplateVariables(template);
+
+      expect(variables).toEqual(['name']);
+    });
+
+    it('should return empty array for no variables', () => {
+      const template = 'No variables here!';
+      const variables = extractTemplateVariables(template);
+
+      expect(variables).toEqual([]);
+    });
+  });
+
+  describe('validateTemplateVariables', () => {
+    it('should return valid for all variables provided', () => {
+      const template = '{{a}} and {{b}}';
+      const variables: TemplateVariables = { a: '1', b: '2' };
+      const result = validateTemplateVariables(template, variables);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should return missing variables when some are not provided', () => {
+      const template = '{{a}}, {{b}}, {{c}}';
+      const variables: TemplateVariables = { a: '1' };
+      const result = validateTemplateVariables(template, variables);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.missingVariables).toContain('b');
+        expect(result.missingVariables).toContain('c');
+      }
+    });
+
+    it('should allow extra variables', () => {
+      const template = '{{a}}';
+      const variables: TemplateVariables = { a: '1', b: '2', c: '3' };
+      const result = validateTemplateVariables(template, variables);
+
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('buildStructuredPrompt', () => {
+    it('should build prompt with sections only', () => {
+      const prompt: StructuredPrompt = {
+        sections: [
+          { title: 'Task', content: 'Do something' },
+          { title: 'Requirements', content: 'Be careful' },
+        ],
+      };
+      const result = buildStructuredPrompt(prompt);
+
+      expect(result).toContain('## Task');
+      expect(result).toContain('Do something');
+      expect(result).toContain('## Requirements');
+      expect(result).toContain('Be careful');
+    });
+
+    it('should include prefix when provided', () => {
+      const prompt: StructuredPrompt = {
+        prefix: 'You are an assistant.',
+        sections: [{ title: 'Task', content: 'Help me' }],
+      };
+      const result = buildStructuredPrompt(prompt);
+
+      expect(result).toMatch(/^You are an assistant\./);
+    });
+
+    it('should include suffix when provided', () => {
+      const prompt: StructuredPrompt = {
+        sections: [{ title: 'Task', content: 'Help me' }],
+        suffix: 'Begin now.',
+      };
+      const result = buildStructuredPrompt(prompt);
+
+      expect(result).toMatch(/Begin now\.$/);
+    });
+
+    it('should respect section levels', () => {
+      const prompt: StructuredPrompt = {
+        sections: [
+          { title: 'Main', content: 'Main content', level: 1 },
+          { title: 'Sub', content: 'Sub content', level: 3 },
+        ],
+      };
+      const result = buildStructuredPrompt(prompt);
+
+      expect(result).toContain('# Main');
+      expect(result).toContain('### Sub');
+    });
+  });
+
+  describe('Common Templates', () => {
+    it('JSON_OUTPUT_INSTRUCTION_JA should contain Japanese instructions', () => {
+      expect(JSON_OUTPUT_INSTRUCTION_JA).toContain('JSON');
+      expect(JSON_OUTPUT_INSTRUCTION_JA).toContain('形式');
+    });
+
+    it('JSON_OUTPUT_INSTRUCTION_EN should contain English instructions', () => {
+      expect(JSON_OUTPUT_INSTRUCTION_EN).toContain('JSON');
+      expect(JSON_OUTPUT_INSTRUCTION_EN).toContain('format');
+    });
+
+    it('JAPANESE_MEETING_INSTRUCTION should contain Japanese meeting guidance', () => {
+      expect(JAPANESE_MEETING_INSTRUCTION).toContain('日本語');
+      expect(JAPANESE_MEETING_INSTRUCTION).toContain('敬語');
+    });
+
+    it('getJsonOutputInstruction should return correct instruction', () => {
+      expect(getJsonOutputInstruction('ja')).toBe(JSON_OUTPUT_INSTRUCTION_JA);
+      expect(getJsonOutputInstruction('en')).toBe(JSON_OUTPUT_INSTRUCTION_EN);
+    });
+  });
+
+  describe('trimText', () => {
+    it('should return text unchanged if under maxLength', () => {
+      const result = trimText('Hello', 10);
+      expect(result).toBe('Hello');
+    });
+
+    it('should trim text and add ellipsis', () => {
+      const result = trimText('Hello World', 8);
+      expect(result).toBe('Hello...');
+    });
+
+    it('should use custom ellipsis', () => {
+      const result = trimText('Hello World', 9, '...(more)');
+      expect(result).toBe('...(more)');
+    });
+
+    it('should handle exact length', () => {
+      const result = trimText('Hello', 5);
+      expect(result).toBe('Hello');
+    });
+  });
+
+  describe('formatList', () => {
+    it('should format as bullet list by default', () => {
+      const result = formatList(['Item 1', 'Item 2']);
+      expect(result).toBe('- Item 1\n- Item 2');
+    });
+
+    it('should format as numbered list', () => {
+      const result = formatList(['First', 'Second', 'Third'], { type: 'numbered' });
+      expect(result).toBe('1. First\n2. Second\n3. Third');
+    });
+
+    it('should format as inline list', () => {
+      const result = formatList(['A', 'B', 'C'], { type: 'inline' });
+      expect(result).toBe('A, B, C');
+    });
+
+    it('should use custom separator for inline', () => {
+      const result = formatList(['A', 'B', 'C'], { type: 'inline', separator: ' | ' });
+      expect(result).toBe('A | B | C');
+    });
+
+    it('should return empty string for empty array', () => {
+      const result = formatList([]);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('estimateTokenCount', () => {
+    it('should estimate tokens for Japanese text', () => {
+      const text = 'こんにちは世界';
+      const count = estimateTokenCount(text);
+      expect(count).toBeGreaterThan(0);
+      expect(count).toBeLessThan(20);
+    });
+
+    it('should estimate tokens for English text', () => {
+      const text = 'Hello world how are you';
+      const count = estimateTokenCount(text);
+      expect(count).toBeGreaterThan(0);
+      expect(count).toBeLessThan(20);
+    });
+
+    it('should estimate tokens for mixed text', () => {
+      const text = 'Hello, 世界! This is a test テスト.';
+      const count = estimateTokenCount(text);
+      expect(count).toBeGreaterThan(0);
+    });
+
+    it('should return 0 for empty text', () => {
+      const count = estimateTokenCount('');
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('splitTranscriptByTokens', () => {
+    it('should not split short transcript', () => {
+      const transcript = 'Line 1\nLine 2\nLine 3';
+      const chunks = splitTranscriptByTokens(transcript, 1000);
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]).toBe(transcript);
+    });
+
+    it('should split long transcript', () => {
+      const lines = Array(100).fill('This is a test line with some content.').join('\n');
+      const chunks = splitTranscriptByTokens(lines, 50);
+      expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    it('should preserve line breaks in chunks', () => {
+      const transcript = 'Line 1\nLine 2\nLine 3';
+      const chunks = splitTranscriptByTokens(transcript, 1000);
+      expect(chunks[0]).toContain('\n');
+    });
+  });
+
+  describe('formatDate', () => {
+    it('should format date in ISO format by default', () => {
+      const result = formatDate(new Date('2025-01-22'));
+      expect(result).toBe('2025-01-22');
+    });
+
+    it('should format date in Japanese format', () => {
+      const result = formatDate('2025-01-22', 'japanese');
+      expect(result).toBe('2025年1月22日');
+    });
+
+    it('should format date in English format', () => {
+      const result = formatDate('2025-01-22', 'english');
+      expect(result).toContain('January');
+      expect(result).toContain('22');
+      expect(result).toContain('2025');
+    });
+
+    it('should accept Date object', () => {
+      const date = new Date('2025-03-15');
+      const result = formatDate(date, 'iso');
+      expect(result).toBe('2025-03-15');
+    });
+
+    it('should throw error for invalid date', () => {
+      expect(() => formatDate('invalid-date')).toThrow('Invalid date');
+    });
+  });
+});

--- a/src/lib/claude/client.ts
+++ b/src/lib/claude/client.ts
@@ -1,0 +1,337 @@
+/**
+ * Claude API Client
+ *
+ * Anthropic Claude APIを使用するためのクライアントクラス
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import { z } from 'zod';
+import type { ZodSchema } from 'zod';
+
+import {
+  ClaudeApiError,
+  ClaudeParseError,
+  DEFAULT_MAX_TOKENS,
+  DEFAULT_MODEL,
+  type ClaudeClientOptions,
+  type ClaudeMessage,
+  type SendMessageOptions,
+  type StructuredOutputOptions,
+} from './types';
+
+/**
+ * Claude APIクライアント
+ *
+ * Anthropic Claude APIとの通信を管理するクラス
+ *
+ * @example
+ * ```typescript
+ * const client = new ClaudeClient(process.env.ANTHROPIC_API_KEY);
+ *
+ * // 単純なメッセージ送信
+ * const response = await client.sendMessage([
+ *   { role: 'user', content: 'Hello, Claude!' }
+ * ]);
+ *
+ * // 構造化出力
+ * const schema = z.object({ name: z.string(), age: z.number() });
+ * const data = await client.generateStructuredOutput(
+ *   [{ role: 'user', content: 'Generate a person' }],
+ *   schema
+ * );
+ * ```
+ */
+export class ClaudeClient {
+  private readonly client: Anthropic;
+  private readonly model: string;
+  private readonly maxTokens: number;
+
+  /**
+   * ClaudeClientを作成
+   *
+   * @param apiKey - Anthropic APIキー
+   * @param options - クライアント設定オプション
+   */
+  constructor(apiKey: string, options?: ClaudeClientOptions) {
+    if (!apiKey || apiKey.trim() === '') {
+      throw new ClaudeApiError('API key is required');
+    }
+
+    this.client = new Anthropic({ apiKey });
+    this.model = options?.model ?? DEFAULT_MODEL;
+    this.maxTokens = options?.maxTokens ?? DEFAULT_MAX_TOKENS;
+  }
+
+  /**
+   * メッセージを送信してテキストレスポンスを取得
+   *
+   * @param messages - 送信するメッセージの配列
+   * @param options - 送信オプション
+   * @returns アシスタントからのテキストレスポンス
+   * @throws {ClaudeApiError} API呼び出しに失敗した場合
+   */
+  async sendMessage(
+    messages: ClaudeMessage[],
+    options?: SendMessageOptions
+  ): Promise<string> {
+    if (messages.length === 0) {
+      throw new ClaudeApiError('At least one message is required');
+    }
+
+    try {
+      const requestParams: Anthropic.MessageCreateParams = {
+        model: this.model,
+        max_tokens: options?.maxTokens ?? this.maxTokens,
+        messages: messages.map((msg) => ({
+          role: msg.role,
+          content: msg.content,
+        })),
+      };
+
+      // systemが指定されている場合のみ追加
+      if (options?.system !== undefined) {
+        requestParams.system = options.system;
+      }
+
+      const response = await this.client.messages.create(requestParams);
+
+      // テキストコンテンツを抽出
+      const textContent = response.content.find(
+        (block): block is Anthropic.TextBlock => block.type === 'text'
+      );
+
+      if (!textContent) {
+        throw new ClaudeApiError('No text content in response');
+      }
+
+      return textContent.text;
+    } catch (error) {
+      if (error instanceof ClaudeApiError) {
+        throw error;
+      }
+
+      // Anthropic APIErrorの判定（error.nameで判定）
+      if (error instanceof Error && error.name === 'APIError') {
+        const apiError = error as { message: string; status?: number };
+        throw new ClaudeApiError(
+          `API request failed: ${apiError.message}`,
+          apiError.status,
+          error
+        );
+      }
+
+      throw new ClaudeApiError(
+        `Unexpected error: ${error instanceof Error ? error.message : String(error)}`,
+        undefined,
+        error
+      );
+    }
+  }
+
+  /**
+   * 構造化出力を生成
+   *
+   * メッセージを送信し、レスポンスをJSONとしてパースしてスキーマで検証
+   *
+   * @param messages - 送信するメッセージの配列
+   * @param schema - 出力を検証するZodスキーマ
+   * @param options - 送信オプション
+   * @returns スキーマに従ってパースされたデータ
+   * @throws {ClaudeApiError} API呼び出しに失敗した場合
+   * @throws {ClaudeParseError} JSONパースまたはスキーマ検証に失敗した場合
+   */
+  async generateStructuredOutput<T>(
+    messages: ClaudeMessage[],
+    schema: ZodSchema<T>,
+    options?: StructuredOutputOptions
+  ): Promise<T> {
+    const retryCount = options?.retryCount ?? 1;
+    let lastError: Error = new Error('Unknown error');
+
+    for (let attempt = 0; attempt <= retryCount; attempt++) {
+      try {
+        // JSON出力を促すシステムプロンプトを構築
+        const systemPrompt = this.buildJsonSystemPrompt(
+          schema,
+          options?.system
+        );
+
+        const response = await this.sendMessage(messages, {
+          ...options,
+          system: systemPrompt,
+        });
+
+        // JSONをパース
+        const parsed = this.parseJsonResponse(response);
+
+        // スキーマで検証
+        const result = schema.safeParse(parsed);
+
+        if (!result.success) {
+          throw new ClaudeParseError(
+            `Schema validation failed: ${result.error.message}`,
+            response,
+            result.error
+          );
+        }
+
+        return result.data;
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+
+        // APIエラーはリトライしない
+        if (error instanceof ClaudeApiError) {
+          throw error;
+        }
+
+        // 最後の試行でもパースエラーならスロー
+        if (attempt === retryCount) {
+          if (error instanceof ClaudeParseError) {
+            throw error;
+          }
+          throw new ClaudeParseError(
+            `Failed to parse structured output: ${lastError.message}`,
+            undefined,
+            lastError
+          );
+        }
+      }
+    }
+
+    // TypeScriptの型システムのためにthrow（実際にはここには到達しない）
+    throw new ClaudeParseError(
+      `Failed after all retries: ${lastError.message}`,
+      undefined,
+      lastError
+    );
+  }
+
+  /**
+   * JSON出力を促すシステムプロンプトを構築
+   */
+  private buildJsonSystemPrompt(
+    schema: ZodSchema<unknown>,
+    baseSystem?: string
+  ): string {
+    const schemaDescription = this.describeSchema(schema);
+
+    const jsonInstruction = `You must respond with valid JSON only. No markdown, no code blocks, no explanations.
+Your response must conform to this schema:
+${schemaDescription}
+
+Respond with the JSON object directly.`;
+
+    if (baseSystem !== undefined && baseSystem !== '') {
+      return `${baseSystem}\n\n${jsonInstruction}`;
+    }
+
+    return jsonInstruction;
+  }
+
+  /**
+   * Zodスキーマを人間が読める形式で記述
+   */
+  private describeSchema(schema: ZodSchema<unknown>): string {
+    // Zodスキーマの内部構造を取得して説明を生成
+    if (schema instanceof z.ZodObject) {
+      const shape = schema.shape as Record<string, z.ZodTypeAny>;
+      const fields = Object.entries(shape)
+        .map(([key, value]) => {
+          const type = this.getZodTypeName(value);
+          const isOptional = value.isOptional();
+          return `  "${key}": ${type}${isOptional ? ' (optional)' : ''}`;
+        })
+        .join(',\n');
+      return `{\n${fields}\n}`;
+    }
+
+    if (schema instanceof z.ZodArray) {
+      const element = schema.element as z.ZodTypeAny;
+      const elementType = this.getZodTypeName(element);
+      return `Array<${elementType}>`;
+    }
+
+    return this.getZodTypeName(schema as z.ZodTypeAny);
+  }
+
+  /**
+   * Zodタイプの名前を取得
+   */
+  private getZodTypeName(schema: z.ZodTypeAny): string {
+    if (schema instanceof z.ZodString) return 'string';
+    if (schema instanceof z.ZodNumber) return 'number';
+    if (schema instanceof z.ZodBoolean) return 'boolean';
+    if (schema instanceof z.ZodArray) {
+      const element = schema.element as z.ZodTypeAny;
+      return `Array<${this.getZodTypeName(element)}>`;
+    }
+    if (schema instanceof z.ZodObject) return 'object';
+    if (schema instanceof z.ZodOptional) {
+      const inner = schema.unwrap() as z.ZodTypeAny;
+      return this.getZodTypeName(inner);
+    }
+    if (schema instanceof z.ZodNullable) {
+      const inner = schema.unwrap() as z.ZodTypeAny;
+      return `${this.getZodTypeName(inner)} | null`;
+    }
+    if (schema instanceof z.ZodEnum) {
+      const options = schema.options as readonly string[];
+      return options.map((o) => `"${o}"`).join(' | ');
+    }
+    if (schema instanceof z.ZodLiteral) {
+      const value = schema.value as unknown;
+      return typeof value === 'string' ? `"${value}"` : String(value);
+    }
+    return 'unknown';
+  }
+
+  /**
+   * レスポンスからJSONをパース
+   */
+  private parseJsonResponse(response: string): unknown {
+    // まず直接パースを試みる
+    try {
+      return JSON.parse(response);
+    } catch {
+      // JSON部分を抽出して再試行
+    }
+
+    // コードブロック内のJSONを抽出
+    const codeBlockMatch = /```(?:json)?\s*([\s\S]*?)```/.exec(response);
+    const codeBlockContent = codeBlockMatch?.[1];
+    if (codeBlockContent !== undefined && codeBlockContent !== '') {
+      try {
+        return JSON.parse(codeBlockContent.trim());
+      } catch {
+        // 抽出失敗
+      }
+    }
+
+    // 最初の { から最後の } までを抽出
+    const jsonMatch = /\{[\s\S]*\}/.exec(response);
+    const jsonContent = jsonMatch?.[0];
+    if (jsonContent !== undefined && jsonContent !== '') {
+      try {
+        return JSON.parse(jsonContent);
+      } catch {
+        // 抽出失敗
+      }
+    }
+
+    // 最初の [ から最後の ] までを抽出（配列の場合）
+    const arrayMatch = /\[[\s\S]*\]/.exec(response);
+    const arrayContent = arrayMatch?.[0];
+    if (arrayContent !== undefined && arrayContent !== '') {
+      try {
+        return JSON.parse(arrayContent);
+      } catch {
+        // 抽出失敗
+      }
+    }
+
+    throw new ClaudeParseError(
+      'Failed to extract valid JSON from response',
+      response
+    );
+  }
+}

--- a/src/lib/claude/index.ts
+++ b/src/lib/claude/index.ts
@@ -1,0 +1,125 @@
+/**
+ * Claude API Library
+ *
+ * Anthropic Claude APIを使用するためのライブラリ
+ *
+ * @example
+ * ```typescript
+ * import { ClaudeClient, ClaudeApiError, ClaudeParseError } from '@/lib/claude';
+ *
+ * const client = new ClaudeClient(process.env.ANTHROPIC_API_KEY);
+ *
+ * // メッセージ送信
+ * const response = await client.sendMessage([
+ *   { role: 'user', content: 'Hello!' }
+ * ]);
+ *
+ * // 構造化出力
+ * import { z } from 'zod';
+ * const schema = z.object({ answer: z.string() });
+ * const data = await client.generateStructuredOutput(messages, schema);
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // 議事録生成
+ * import {
+ *   ClaudeClient,
+ *   MINUTES_GENERATION_SYSTEM_PROMPT,
+ *   buildMinutesGenerationPrompt,
+ *   minutesOutputSchema,
+ * } from '@/lib/claude';
+ *
+ * const prompt = buildMinutesGenerationPrompt({
+ *   transcript: '...',
+ *   meetingTitle: '定例会議',
+ *   meetingDate: '2025-01-22',
+ *   attendees: ['田中', '鈴木'],
+ * });
+ *
+ * const minutes = await client.generateStructuredOutput(
+ *   [{ role: 'user', content: prompt }],
+ *   minutesOutputSchema,
+ *   { system: MINUTES_GENERATION_SYSTEM_PROMPT }
+ * );
+ * ```
+ */
+
+// Client
+export { ClaudeClient } from './client';
+
+// Types
+export type {
+  ClaudeClientOptions,
+  ClaudeMessage,
+  ClaudeRequest,
+  ClaudeResponse,
+  ContentBlock,
+  MessageRole,
+  SendMessageOptions,
+  StopReason,
+  StructuredOutputOptions,
+  Usage,
+} from './types';
+
+// Error classes
+export { ClaudeApiError, ClaudeParseError } from './types';
+
+// Zod schemas
+export {
+  ClaudeMessageSchema,
+  ClaudeRequestSchema,
+  ClaudeResponseSchema,
+  ContentBlockSchema,
+  MessageRoleSchema,
+  StopReasonSchema,
+  UsageSchema,
+} from './types';
+
+// Constants
+export { DEFAULT_MAX_TOKENS, DEFAULT_MODEL } from './types';
+
+// =============================================================================
+// Prompt Templates
+// =============================================================================
+
+// Minutes Generation
+export {
+  MINUTES_GENERATION_SYSTEM_PROMPT,
+  getSystemPrompt,
+  buildMinutesGenerationPrompt,
+  minutesOutputSchema,
+  MinutesOutputSpeakerSchema,
+  MinutesOutputTopicSchema,
+  MinutesOutputDecisionSchema,
+  MinutesOutputActionItemSchema,
+  validateMinutesGenerationInput,
+  validateMinutesOutput,
+  type MinutesGenerationInput,
+  type OutputLanguage,
+  type MinutesOutput,
+  type MinutesOutputSpeaker,
+  type MinutesOutputTopic,
+  type MinutesOutputDecision,
+  type MinutesOutputActionItem,
+} from './prompts/index';
+
+// Template Utilities
+export {
+  replaceTemplateVariables,
+  extractTemplateVariables,
+  validateTemplateVariables,
+  buildStructuredPrompt,
+  JSON_OUTPUT_INSTRUCTION_JA,
+  JSON_OUTPUT_INSTRUCTION_EN,
+  JAPANESE_MEETING_INSTRUCTION,
+  getJsonOutputInstruction,
+  trimText,
+  formatList,
+  estimateTokenCount,
+  splitTranscriptByTokens,
+  formatDate,
+  type TemplateVariables,
+  type PromptSection,
+  type StructuredPrompt,
+} from './prompts/index';

--- a/src/lib/claude/prompts/index.ts
+++ b/src/lib/claude/prompts/index.ts
@@ -1,0 +1,96 @@
+/**
+ * Claude Prompt Templates
+ *
+ * AIプロンプトテンプレートのエクスポート
+ *
+ * @module lib/claude/prompts
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   MINUTES_GENERATION_SYSTEM_PROMPT,
+ *   buildMinutesGenerationPrompt,
+ *   minutesOutputSchema,
+ * } from '@/lib/claude/prompts';
+ *
+ * // プロンプト構築
+ * const userPrompt = buildMinutesGenerationPrompt({
+ *   transcript: '...',
+ *   meetingTitle: '週次定例会議',
+ *   meetingDate: '2025-01-22',
+ *   attendees: ['田中', '鈴木'],
+ * });
+ *
+ * // ClaudeClientで使用
+ * const result = await client.generateStructuredOutput(
+ *   [{ role: 'user', content: userPrompt }],
+ *   minutesOutputSchema,
+ *   { system: MINUTES_GENERATION_SYSTEM_PROMPT }
+ * );
+ * ```
+ */
+
+// =============================================================================
+// Minutes Generation
+// =============================================================================
+
+export {
+  // System Prompt
+  MINUTES_GENERATION_SYSTEM_PROMPT,
+  getSystemPrompt,
+
+  // User Prompt Builder
+  buildMinutesGenerationPrompt,
+
+  // Output Schema
+  minutesOutputSchema,
+  MinutesOutputSpeakerSchema,
+  MinutesOutputTopicSchema,
+  MinutesOutputDecisionSchema,
+  MinutesOutputActionItemSchema,
+
+  // Validation
+  validateMinutesGenerationInput,
+  validateMinutesOutput,
+
+  // Types
+  type MinutesGenerationInput,
+  type OutputLanguage,
+  type MinutesOutput,
+  type MinutesOutputSpeaker,
+  type MinutesOutputTopic,
+  type MinutesOutputDecision,
+  type MinutesOutputActionItem,
+} from './minutes-generation';
+
+// =============================================================================
+// Shared Templates and Utilities
+// =============================================================================
+
+export {
+  // Template Processing
+  replaceTemplateVariables,
+  extractTemplateVariables,
+  validateTemplateVariables,
+
+  // Structured Prompt Building
+  buildStructuredPrompt,
+
+  // Common Templates
+  JSON_OUTPUT_INSTRUCTION_JA,
+  JSON_OUTPUT_INSTRUCTION_EN,
+  JAPANESE_MEETING_INSTRUCTION,
+  getJsonOutputInstruction,
+
+  // Utility Functions
+  trimText,
+  formatList,
+  estimateTokenCount,
+  splitTranscriptByTokens,
+  formatDate,
+
+  // Types
+  type TemplateVariables,
+  type PromptSection,
+  type StructuredPrompt,
+} from './templates';

--- a/src/lib/claude/prompts/minutes-generation.ts
+++ b/src/lib/claude/prompts/minutes-generation.ts
@@ -1,0 +1,435 @@
+/**
+ * Minutes Generation Prompts
+ *
+ * 議事録生成用のAIプロンプトテンプレート
+ *
+ * @module lib/claude/prompts/minutes-generation
+ */
+
+import { z } from 'zod';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * 議事録生成プロンプトの入力パラメータ
+ */
+export interface MinutesGenerationInput {
+  /** 文字起こしテキスト */
+  transcript: string;
+  /** 会議タイトル */
+  meetingTitle: string;
+  /** 会議日（YYYY-MM-DD形式） */
+  meetingDate: string;
+  /** 参加者名の配列 */
+  attendees: string[];
+  /** 出力言語（デフォルト: 'ja'） */
+  language?: 'ja' | 'en';
+}
+
+/**
+ * 出力言語設定
+ */
+export type OutputLanguage = 'ja' | 'en';
+
+// =============================================================================
+// System Prompt
+// =============================================================================
+
+/**
+ * 日本語システムプロンプト
+ */
+const SYSTEM_PROMPT_JA = `あなたは議事録作成の専門家です。
+会議の文字起こしから、構造化された高品質な議事録を作成することが得意です。
+
+あなたの役割:
+- 会議の内容を正確に把握し、重要な情報を漏らさず抽出する
+- 話題の流れを理解し、論理的にセグメント分けする
+- 決定事項とアクションアイテムを明確に識別する
+- 簡潔で読みやすい文章で要約する
+
+出力形式:
+- 必ずJSON形式で出力してください
+- マークダウンやコードブロックは使用しないでください
+- 指定されたスキーマに厳密に従ってください`;
+
+/**
+ * 英語システムプロンプト
+ */
+const SYSTEM_PROMPT_EN = `You are an expert meeting minutes creator.
+You excel at creating structured, high-quality meeting minutes from transcripts.
+
+Your role:
+- Accurately understand the meeting content and extract all important information
+- Understand the flow of topics and logically segment them
+- Clearly identify decisions and action items
+- Summarize in concise, readable prose
+
+Output format:
+- Always output in JSON format
+- Do not use markdown or code blocks
+- Strictly follow the specified schema`;
+
+/**
+ * 議事録生成用システムプロンプト
+ *
+ * 日本語会議に最適化されたシステムプロンプト。
+ * 役割、出力形式、期待される品質基準を定義します。
+ */
+export const MINUTES_GENERATION_SYSTEM_PROMPT = SYSTEM_PROMPT_JA;
+
+/**
+ * 言語別システムプロンプトを取得
+ *
+ * @param language - 出力言語
+ * @returns システムプロンプト文字列
+ */
+export function getSystemPrompt(language: OutputLanguage = 'ja'): string {
+  return language === 'ja' ? SYSTEM_PROMPT_JA : SYSTEM_PROMPT_EN;
+}
+
+// =============================================================================
+// User Prompt Builder
+// =============================================================================
+
+/**
+ * 日本語ユーザープロンプトテンプレート
+ */
+const USER_PROMPT_TEMPLATE_JA = `以下の会議の文字起こしから、構造化された議事録を作成してください。
+
+## 出力要件
+
+### 1. 全体要約 (summary)
+- 3-5文で会議全体の要点を簡潔にまとめてください
+- 会議の目的、主な議論点、結論を含めてください
+
+### 2. 話題セグメント (topics)
+- 議論の流れに沿って話題を分割してください
+- 各話題には以下を含めてください:
+  - title: 話題のタイトル（簡潔に）
+  - startTime: 開始時間（ミリ秒、推定で構いません）
+  - endTime: 終了時間（ミリ秒、推定で構いません）
+  - summary: 話題の要約（1-2文）
+  - keyPoints: 主要なポイント（配列）
+  - speakers: 発言者（参加者リストから選択）
+
+### 3. 決定事項 (decisions)
+- 「決定」「承認」「合意」「決まった」「採用」等のキーワードから抽出
+- 各決定事項には以下を含めてください:
+  - content: 決定内容
+  - context: 決定の背景や理由
+  - decidedAt: 決定時間（ミリ秒、推定で構いません）
+- 明確な決定がない場合は空配列で構いません
+
+### 4. アクションアイテム (actionItems)
+- 「やる」「対応する」「確認する」「作成する」等のキーワードから抽出
+- 各アクションアイテムには以下を含めてください:
+  - content: タスク内容
+  - assignee: 担当者（検出できた場合、参加者から選択）
+  - dueDate: 期限（YYYY-MM-DD形式、検出できた場合）
+  - priority: 優先度推定（"high", "medium", "low"）
+- 明確なアクションがない場合は空配列で構いません
+
+## 会議情報
+タイトル: {{meetingTitle}}
+日付: {{meetingDate}}
+参加者: {{attendees}}
+
+## 文字起こし
+{{transcript}}
+
+## 重要な注意事項
+- IDフィールド（id）は含めないでください（サーバー側で生成します）
+- 発言者情報はidとnameのみで構いません
+- 時間は推定値で構いません（0から始まるミリ秒単位）
+- 検出できない情報は省略可能なフィールドとして扱ってください`;
+
+/**
+ * 英語ユーザープロンプトテンプレート
+ */
+const USER_PROMPT_TEMPLATE_EN = `Create structured meeting minutes from the following transcript.
+
+## Output Requirements
+
+### 1. Overall Summary (summary)
+- Summarize the entire meeting in 3-5 sentences
+- Include the meeting purpose, main discussion points, and conclusions
+
+### 2. Topic Segments (topics)
+- Divide topics following the flow of discussion
+- Each topic should include:
+  - title: Topic title (concise)
+  - startTime: Start time (milliseconds, estimate is fine)
+  - endTime: End time (milliseconds, estimate is fine)
+  - summary: Topic summary (1-2 sentences)
+  - keyPoints: Key points (array)
+  - speakers: Speakers (select from attendee list)
+
+### 3. Decisions (decisions)
+- Extract from keywords like "decided", "approved", "agreed", "adopted"
+- Each decision should include:
+  - content: Decision content
+  - context: Background or reason for the decision
+  - decidedAt: Decision time (milliseconds, estimate is fine)
+- Empty array is acceptable if no clear decisions
+
+### 4. Action Items (actionItems)
+- Extract from keywords like "will do", "handle", "check", "create"
+- Each action item should include:
+  - content: Task content
+  - assignee: Assignee (if detected, select from attendees)
+  - dueDate: Due date (YYYY-MM-DD format, if detected)
+  - priority: Estimated priority ("high", "medium", "low")
+- Empty array is acceptable if no clear actions
+
+## Meeting Information
+Title: {{meetingTitle}}
+Date: {{meetingDate}}
+Attendees: {{attendees}}
+
+## Transcript
+{{transcript}}
+
+## Important Notes
+- Do not include ID fields (id) - they will be generated server-side
+- Speaker info only needs id and name
+- Times can be estimates (milliseconds starting from 0)
+- Treat undetectable information as optional fields`;
+
+/**
+ * 議事録生成用ユーザープロンプトを構築
+ *
+ * @param input - プロンプト生成に必要な入力パラメータ
+ * @returns 構築されたユーザープロンプト文字列
+ *
+ * @example
+ * ```typescript
+ * const prompt = buildMinutesGenerationPrompt({
+ *   transcript: '田中: おはようございます。本日の議題は...',
+ *   meetingTitle: '週次定例会議',
+ *   meetingDate: '2025-01-22',
+ *   attendees: ['田中', '鈴木', '佐藤'],
+ *   language: 'ja',
+ * });
+ * ```
+ */
+export function buildMinutesGenerationPrompt(input: MinutesGenerationInput): string {
+  const {
+    transcript,
+    meetingTitle,
+    meetingDate,
+    attendees,
+    language = 'ja',
+  } = input;
+
+  // 入力値のバリデーション
+  if (!transcript || transcript.trim() === '') {
+    throw new Error('Transcript is required and cannot be empty');
+  }
+  if (!meetingTitle || meetingTitle.trim() === '') {
+    throw new Error('Meeting title is required and cannot be empty');
+  }
+  if (!meetingDate || meetingDate.trim() === '') {
+    throw new Error('Meeting date is required and cannot be empty');
+  }
+
+  const template = language === 'ja' ? USER_PROMPT_TEMPLATE_JA : USER_PROMPT_TEMPLATE_EN;
+  const attendeesStr = attendees.length > 0 ? attendees.join(', ') : '(Not specified)';
+
+  return template
+    .replace('{{meetingTitle}}', meetingTitle)
+    .replace('{{meetingDate}}', meetingDate)
+    .replace('{{attendees}}', attendeesStr)
+    .replace('{{transcript}}', transcript);
+}
+
+// =============================================================================
+// Output Schema (Zod)
+// =============================================================================
+
+/**
+ * AI出力用の発言者スキーマ（IDなし - サーバー側で生成）
+ */
+export const MinutesOutputSpeakerSchema = z.object({
+  /** 発言者名 */
+  name: z.string().min(1),
+  /** Lark ユーザーID（オプション） */
+  larkUserId: z.string().optional(),
+});
+
+/**
+ * AI出力用の話題セグメントスキーマ（IDなし）
+ */
+export const MinutesOutputTopicSchema = z.object({
+  /** 話題タイトル */
+  title: z.string().min(1),
+  /** 開始時間（ミリ秒） */
+  startTime: z.number().int().nonnegative(),
+  /** 終了時間（ミリ秒） */
+  endTime: z.number().int().nonnegative(),
+  /** 話題の要約 */
+  summary: z.string(),
+  /** 主要ポイント */
+  keyPoints: z.array(z.string()),
+  /** 発言者 */
+  speakers: z.array(MinutesOutputSpeakerSchema).optional(),
+});
+
+/**
+ * AI出力用の決定事項スキーマ（IDなし）
+ */
+export const MinutesOutputDecisionSchema = z.object({
+  /** 決定内容 */
+  content: z.string().min(1),
+  /** 背景・理由 */
+  context: z.string(),
+  /** 決定時間（ミリ秒） */
+  decidedAt: z.number().int().nonnegative(),
+});
+
+/**
+ * AI出力用のアクションアイテムスキーマ（IDなし）
+ */
+export const MinutesOutputActionItemSchema = z.object({
+  /** タスク内容 */
+  content: z.string().min(1),
+  /** 担当者（オプション） */
+  assignee: MinutesOutputSpeakerSchema.optional(),
+  /** 期限（YYYY-MM-DD形式、オプション） */
+  dueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  /** 優先度 */
+  priority: z.enum(['high', 'medium', 'low']),
+});
+
+/**
+ * AI出力用の議事録スキーマ（IDなし - 簡略版）
+ *
+ * Claude APIからの構造化出力を検証するためのスキーマ。
+ * IDフィールドはサーバー側で生成するため、含まれていません。
+ *
+ * @example
+ * ```typescript
+ * import { ClaudeClient } from '@/lib/claude';
+ *
+ * const client = new ClaudeClient(apiKey);
+ * const result = await client.generateStructuredOutput(
+ *   messages,
+ *   minutesOutputSchema,
+ *   { system: MINUTES_GENERATION_SYSTEM_PROMPT }
+ * );
+ * ```
+ */
+export const minutesOutputSchema = z.object({
+  /** 全体要約（3-5文） */
+  summary: z.string().min(1),
+  /** 話題セグメント */
+  topics: z.array(MinutesOutputTopicSchema),
+  /** 決定事項 */
+  decisions: z.array(MinutesOutputDecisionSchema),
+  /** アクションアイテム */
+  actionItems: z.array(MinutesOutputActionItemSchema),
+  /** 参加者（出力から抽出された場合） */
+  attendees: z.array(MinutesOutputSpeakerSchema).optional(),
+});
+
+/**
+ * AI出力の議事録型
+ */
+export type MinutesOutput = z.infer<typeof minutesOutputSchema>;
+
+/**
+ * AI出力の発言者型
+ */
+export type MinutesOutputSpeaker = z.infer<typeof MinutesOutputSpeakerSchema>;
+
+/**
+ * AI出力の話題セグメント型
+ */
+export type MinutesOutputTopic = z.infer<typeof MinutesOutputTopicSchema>;
+
+/**
+ * AI出力の決定事項型
+ */
+export type MinutesOutputDecision = z.infer<typeof MinutesOutputDecisionSchema>;
+
+/**
+ * AI出力のアクションアイテム型
+ */
+export type MinutesOutputActionItem = z.infer<typeof MinutesOutputActionItemSchema>;
+
+// =============================================================================
+// Validation Helpers
+// =============================================================================
+
+/**
+ * 議事録生成入力をバリデート
+ *
+ * @param input - バリデートする入力
+ * @returns バリデーション結果
+ */
+export function validateMinutesGenerationInput(
+  input: unknown
+): { valid: true; data: MinutesGenerationInput } | { valid: false; errors: string[] } {
+  const errors: string[] = [];
+
+  if (typeof input !== 'object' || input === null) {
+    return { valid: false, errors: ['Input must be an object'] };
+  }
+
+  const obj = input as Record<string, unknown>;
+
+  if (typeof obj.transcript !== 'string' || obj.transcript.trim() === '') {
+    errors.push('transcript is required and must be a non-empty string');
+  }
+
+  if (typeof obj.meetingTitle !== 'string' || obj.meetingTitle.trim() === '') {
+    errors.push('meetingTitle is required and must be a non-empty string');
+  }
+
+  if (typeof obj.meetingDate !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(obj.meetingDate)) {
+    errors.push('meetingDate is required and must be in YYYY-MM-DD format');
+  }
+
+  if (!Array.isArray(obj.attendees)) {
+    errors.push('attendees must be an array of strings');
+  } else {
+    const invalidAttendees = obj.attendees.filter(
+      (a: unknown) => typeof a !== 'string'
+    );
+    if (invalidAttendees.length > 0) {
+      errors.push('All attendees must be strings');
+    }
+  }
+
+  if (obj.language !== undefined && obj.language !== 'ja' && obj.language !== 'en') {
+    errors.push('language must be "ja" or "en"');
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    data: {
+      transcript: obj.transcript as string,
+      meetingTitle: obj.meetingTitle as string,
+      meetingDate: obj.meetingDate as string,
+      attendees: obj.attendees as string[],
+      language: (obj.language as OutputLanguage | undefined) ?? 'ja',
+    },
+  };
+}
+
+/**
+ * AI出力をバリデート
+ *
+ * @param output - バリデートする出力
+ * @returns Zodのパース結果
+ */
+export function validateMinutesOutput(
+  output: unknown
+): z.SafeParseReturnType<unknown, MinutesOutput> {
+  return minutesOutputSchema.safeParse(output);
+}

--- a/src/lib/claude/prompts/templates.ts
+++ b/src/lib/claude/prompts/templates.ts
@@ -1,0 +1,383 @@
+/**
+ * Shared Prompt Templates and Utilities
+ *
+ * プロンプトテンプレートの共通ユーティリティ
+ *
+ * @module lib/claude/prompts/templates
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * テンプレート変数の型
+ */
+export type TemplateVariables = Record<string, string | number | boolean | string[]>;
+
+/**
+ * プロンプトセクションの型
+ */
+export interface PromptSection {
+  /** セクションのタイトル */
+  title: string;
+  /** セクションの内容 */
+  content: string;
+  /** セクションのレベル（マークダウンのヘッダーレベル） */
+  level?: 1 | 2 | 3 | 4;
+}
+
+/**
+ * 構造化プロンプトの型
+ */
+export interface StructuredPrompt {
+  /** プロンプトのセクション配列 */
+  sections: PromptSection[];
+  /** プレフィックステキスト */
+  prefix?: string;
+  /** サフィックステキスト */
+  suffix?: string;
+}
+
+// =============================================================================
+// Template Processing
+// =============================================================================
+
+/**
+ * テンプレート文字列の変数を置換
+ *
+ * @param template - プレースホルダーを含むテンプレート文字列
+ * @param variables - 置換する変数のオブジェクト
+ * @param options - 置換オプション
+ * @returns 変数が置換された文字列
+ *
+ * @example
+ * ```typescript
+ * const result = replaceTemplateVariables(
+ *   'Hello, {{name}}! Today is {{date}}.',
+ *   { name: 'World', date: '2025-01-22' }
+ * );
+ * // => 'Hello, World! Today is 2025-01-22.'
+ * ```
+ */
+export function replaceTemplateVariables(
+  template: string,
+  variables: TemplateVariables,
+  options?: {
+    /** 配列の区切り文字（デフォルト: ', '） */
+    arraySeparator?: string;
+    /** 見つからない変数の処理方法 */
+    missingVariableHandling?: 'keep' | 'remove' | 'error';
+  }
+): string {
+  const { arraySeparator = ', ', missingVariableHandling = 'keep' } = options ?? {};
+
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key: string) => {
+    const value = variables[key];
+
+    if (value === undefined) {
+      switch (missingVariableHandling) {
+        case 'remove':
+          return '';
+        case 'error':
+          throw new Error(`Template variable '${key}' is not defined`);
+        case 'keep':
+        default:
+          return match;
+      }
+    }
+
+    if (Array.isArray(value)) {
+      return value.join(arraySeparator);
+    }
+
+    return String(value);
+  });
+}
+
+/**
+ * テンプレート文字列から変数名を抽出
+ *
+ * @param template - テンプレート文字列
+ * @returns 変数名の配列
+ *
+ * @example
+ * ```typescript
+ * const vars = extractTemplateVariables('Hello, {{name}}! {{greeting}}');
+ * // => ['name', 'greeting']
+ * ```
+ */
+export function extractTemplateVariables(template: string): string[] {
+  const variables = new Set<string>();
+  const regex = /\{\{(\w+)\}\}/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(template)) !== null) {
+    const varName = match[1];
+    if (varName !== undefined && varName !== '') {
+      variables.add(varName);
+    }
+  }
+
+  return Array.from(variables);
+}
+
+/**
+ * テンプレートの必須変数が全て提供されているか確認
+ *
+ * @param template - テンプレート文字列
+ * @param variables - 提供された変数
+ * @returns 検証結果
+ */
+export function validateTemplateVariables(
+  template: string,
+  variables: TemplateVariables
+): { valid: true } | { valid: false; missingVariables: string[] } {
+  const required = extractTemplateVariables(template);
+  const provided = new Set(Object.keys(variables));
+  const missing = required.filter((v) => !provided.has(v));
+
+  if (missing.length > 0) {
+    return { valid: false, missingVariables: missing };
+  }
+
+  return { valid: true };
+}
+
+// =============================================================================
+// Structured Prompt Building
+// =============================================================================
+
+/**
+ * セクションをマークダウン形式でフォーマット
+ *
+ * @param section - プロンプトセクション
+ * @returns フォーマットされた文字列
+ */
+function formatSection(section: PromptSection): string {
+  const level = section.level ?? 2;
+  const header = '#'.repeat(level);
+  return `${header} ${section.title}\n${section.content}`;
+}
+
+/**
+ * 構造化プロンプトを構築
+ *
+ * @param prompt - 構造化プロンプト定義
+ * @returns 構築されたプロンプト文字列
+ *
+ * @example
+ * ```typescript
+ * const prompt = buildStructuredPrompt({
+ *   prefix: 'You are an assistant.',
+ *   sections: [
+ *     { title: 'Task', content: 'Do something', level: 2 },
+ *     { title: 'Requirements', content: '- Item 1\n- Item 2', level: 2 },
+ *   ],
+ *   suffix: 'Begin now.',
+ * });
+ * ```
+ */
+export function buildStructuredPrompt(prompt: StructuredPrompt): string {
+  const parts: string[] = [];
+
+  if (prompt.prefix !== undefined && prompt.prefix !== '') {
+    parts.push(prompt.prefix);
+  }
+
+  for (const section of prompt.sections) {
+    parts.push(formatSection(section));
+  }
+
+  if (prompt.suffix !== undefined && prompt.suffix !== '') {
+    parts.push(prompt.suffix);
+  }
+
+  return parts.join('\n\n');
+}
+
+// =============================================================================
+// Common Templates
+// =============================================================================
+
+/**
+ * JSON出力指示テンプレート（日本語）
+ */
+export const JSON_OUTPUT_INSTRUCTION_JA = `## 出力形式
+
+- 必ずJSON形式で出力してください
+- マークダウンのコードブロック(\`\`\`)は使用しないでください
+- 説明文は含めず、JSONオブジェクトのみを出力してください`;
+
+/**
+ * JSON出力指示テンプレート（英語）
+ */
+export const JSON_OUTPUT_INSTRUCTION_EN = `## Output Format
+
+- Always output in JSON format
+- Do not use markdown code blocks (\`\`\`)
+- Output only the JSON object without explanations`;
+
+/**
+ * 日本語会議用の共通指示
+ */
+export const JAPANESE_MEETING_INSTRUCTION = `## 日本語会議の処理指針
+
+- 敬語や丁寧語を適切に処理してください
+- 日本特有の会議文化（挨拶、確認、合意形成）を考慮してください
+- 曖昧な表現（「検討します」「前向きに」等）の解釈に注意してください
+- 「よろしくお願いします」等の定型句は要約から除外してください`;
+
+/**
+ * 言語に応じたJSON出力指示を取得
+ *
+ * @param language - 言語コード
+ * @returns JSON出力指示文字列
+ */
+export function getJsonOutputInstruction(language: 'ja' | 'en'): string {
+  return language === 'ja' ? JSON_OUTPUT_INSTRUCTION_JA : JSON_OUTPUT_INSTRUCTION_EN;
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+/**
+ * テキストを指定した長さでトリム（省略記号付き）
+ *
+ * @param text - トリムするテキスト
+ * @param maxLength - 最大長
+ * @param ellipsis - 省略記号（デフォルト: '...'）
+ * @returns トリムされたテキスト
+ */
+export function trimText(text: string, maxLength: number, ellipsis: string = '...'): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return text.substring(0, maxLength - ellipsis.length) + ellipsis;
+}
+
+/**
+ * 配列をフォーマットされたリストに変換
+ *
+ * @param items - リストアイテム
+ * @param options - フォーマットオプション
+ * @returns フォーマットされたリスト文字列
+ */
+export function formatList(
+  items: string[],
+  options?: {
+    /** リストの種類（デフォルト: 'bullet'） */
+    type?: 'bullet' | 'numbered' | 'inline';
+    /** インライン時の区切り文字 */
+    separator?: string;
+  }
+): string {
+  const { type = 'bullet', separator = ', ' } = options ?? {};
+
+  if (items.length === 0) {
+    return '';
+  }
+
+  switch (type) {
+    case 'numbered':
+      return items.map((item, i) => `${i + 1}. ${item}`).join('\n');
+    case 'inline':
+      return items.join(separator);
+    case 'bullet':
+    default:
+      return items.map((item) => `- ${item}`).join('\n');
+  }
+}
+
+/**
+ * プロンプトのトークン数を概算（簡易版）
+ *
+ * 正確なトークン数ではなく、概算値を返します。
+ * 日本語は1文字あたり約1.5トークン、英語は1単語あたり約1.3トークンとして計算。
+ *
+ * @param text - テキスト
+ * @returns 概算トークン数
+ */
+export function estimateTokenCount(text: string): number {
+  // 日本語文字（ひらがな、カタカナ、漢字）をカウント
+  const japaneseChars = (text.match(/[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]/g) || []).length;
+
+  // 英語単語をカウント
+  const englishWords = (text.match(/[a-zA-Z]+/g) || []).length;
+
+  // その他の文字（数字、記号等）
+  const otherChars = text.length - japaneseChars - (text.match(/[a-zA-Z]+/g) || []).join('').length;
+
+  // 概算: 日本語1文字=1.5トークン、英語1単語=1.3トークン、その他=0.5トークン
+  return Math.ceil(japaneseChars * 1.5 + englishWords * 1.3 + otherChars * 0.5);
+}
+
+/**
+ * 文字起こしテキストを指定トークン数以内に分割
+ *
+ * @param transcript - 文字起こしテキスト
+ * @param maxTokens - 最大トークン数
+ * @returns 分割されたテキストの配列
+ */
+export function splitTranscriptByTokens(transcript: string, maxTokens: number): string[] {
+  const lines = transcript.split('\n');
+  const chunks: string[] = [];
+  let currentChunk: string[] = [];
+  let currentTokens = 0;
+
+  for (const line of lines) {
+    const lineTokens = estimateTokenCount(line);
+
+    if (currentTokens + lineTokens > maxTokens && currentChunk.length > 0) {
+      chunks.push(currentChunk.join('\n'));
+      currentChunk = [];
+      currentTokens = 0;
+    }
+
+    currentChunk.push(line);
+    currentTokens += lineTokens;
+  }
+
+  if (currentChunk.length > 0) {
+    chunks.push(currentChunk.join('\n'));
+  }
+
+  return chunks;
+}
+
+/**
+ * 日付文字列をフォーマット
+ *
+ * @param date - Date オブジェクトまたは日付文字列
+ * @param format - フォーマット形式
+ * @returns フォーマットされた日付文字列
+ */
+export function formatDate(
+  date: Date | string,
+  format: 'iso' | 'japanese' | 'english' = 'iso'
+): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+
+  if (isNaN(d.getTime())) {
+    throw new Error('Invalid date');
+  }
+
+  const year = d.getFullYear();
+  const month = d.getMonth() + 1;
+  const day = d.getDate();
+
+  switch (format) {
+    case 'japanese':
+      return `${year}年${month}月${day}日`;
+    case 'english':
+      return d.toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      });
+    case 'iso':
+    default:
+      return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  }
+}

--- a/src/lib/claude/types.ts
+++ b/src/lib/claude/types.ts
@@ -1,0 +1,193 @@
+/**
+ * Claude API Type Definitions
+ *
+ * Anthropic Claude APIを使用するための型定義とZodスキーマ
+ */
+
+import { z } from 'zod';
+
+// =============================================================================
+// Custom Error Classes
+// =============================================================================
+
+/**
+ * Claude API呼び出し時のエラー
+ */
+export class ClaudeApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'ClaudeApiError';
+    Object.setPrototypeOf(this, ClaudeApiError.prototype);
+  }
+}
+
+/**
+ * Claude レスポンスのパースエラー
+ */
+export class ClaudeParseError extends Error {
+  constructor(
+    message: string,
+    public readonly rawContent?: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'ClaudeParseError';
+    Object.setPrototypeOf(this, ClaudeParseError.prototype);
+  }
+}
+
+// =============================================================================
+// Zod Schemas
+// =============================================================================
+
+/**
+ * メッセージロールのスキーマ
+ */
+export const MessageRoleSchema = z.enum(['user', 'assistant']);
+
+/**
+ * メッセージ型のスキーマ
+ */
+export const ClaudeMessageSchema = z.object({
+  role: MessageRoleSchema,
+  content: z.string(),
+});
+
+/**
+ * リクエスト型のスキーマ
+ */
+export const ClaudeRequestSchema = z.object({
+  model: z.string(),
+  max_tokens: z.number().int().positive(),
+  messages: z.array(ClaudeMessageSchema).min(1),
+  system: z.string().optional(),
+});
+
+/**
+ * コンテンツブロックのスキーマ
+ */
+export const ContentBlockSchema = z.object({
+  type: z.literal('text'),
+  text: z.string(),
+});
+
+/**
+ * Usage情報のスキーマ
+ */
+export const UsageSchema = z.object({
+  input_tokens: z.number().int().nonnegative(),
+  output_tokens: z.number().int().nonnegative(),
+});
+
+/**
+ * Stop reasonのスキーマ
+ */
+export const StopReasonSchema = z.enum([
+  'end_turn',
+  'max_tokens',
+  'stop_sequence',
+  'tool_use',
+]);
+
+/**
+ * レスポンス型のスキーマ
+ */
+export const ClaudeResponseSchema = z.object({
+  id: z.string(),
+  type: z.literal('message'),
+  role: z.literal('assistant'),
+  content: z.array(ContentBlockSchema),
+  model: z.string(),
+  stop_reason: StopReasonSchema.nullable(),
+  stop_sequence: z.string().nullable(),
+  usage: UsageSchema,
+});
+
+// =============================================================================
+// TypeScript Types (inferred from Zod schemas)
+// =============================================================================
+
+/**
+ * メッセージロール
+ */
+export type MessageRole = z.infer<typeof MessageRoleSchema>;
+
+/**
+ * Claudeメッセージ型
+ */
+export type ClaudeMessage = z.infer<typeof ClaudeMessageSchema>;
+
+/**
+ * Claudeリクエスト型
+ */
+export type ClaudeRequest = z.infer<typeof ClaudeRequestSchema>;
+
+/**
+ * コンテンツブロック型
+ */
+export type ContentBlock = z.infer<typeof ContentBlockSchema>;
+
+/**
+ * Usage情報型
+ */
+export type Usage = z.infer<typeof UsageSchema>;
+
+/**
+ * Stop reason型
+ */
+export type StopReason = z.infer<typeof StopReasonSchema>;
+
+/**
+ * Claudeレスポンス型
+ */
+export type ClaudeResponse = z.infer<typeof ClaudeResponseSchema>;
+
+// =============================================================================
+// Client Configuration Types
+// =============================================================================
+
+/**
+ * ClaudeClientの設定オプション
+ */
+export interface ClaudeClientOptions {
+  /** 使用するモデル（デフォルト: claude-sonnet-4-20250514） */
+  model?: string;
+  /** 最大トークン数（デフォルト: 4096） */
+  maxTokens?: number;
+}
+
+/**
+ * メッセージ送信のオプション
+ */
+export interface SendMessageOptions {
+  /** システムプロンプト */
+  system?: string;
+  /** 最大トークン数（クライアント設定を上書き） */
+  maxTokens?: number;
+}
+
+/**
+ * 構造化出力のオプション
+ */
+export interface StructuredOutputOptions extends SendMessageOptions {
+  /** JSONパース失敗時のリトライ回数（デフォルト: 1） */
+  retryCount?: number;
+}
+
+// =============================================================================
+// Default Values
+// =============================================================================
+
+/**
+ * デフォルトモデル
+ */
+export const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+
+/**
+ * デフォルト最大トークン数
+ */
+export const DEFAULT_MAX_TOKENS = 4096;

--- a/src/services/__tests__/minutes-generation.service.test.ts
+++ b/src/services/__tests__/minutes-generation.service.test.ts
@@ -1,0 +1,754 @@
+/**
+ * MinutesGenerationService tests
+ * @module services/__tests__/minutes-generation.service.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  MinutesGenerationService,
+  MinutesGenerationError,
+  createMinutesGenerationServiceWithClient,
+  type MinutesGenerationInput,
+} from '../minutes-generation.service';
+import { ClaudeClient, ClaudeApiError, ClaudeParseError } from '@/lib/claude';
+import type { Transcript, TranscriptSegment, Speaker } from '@/types/transcript';
+import type { MinutesOutput } from '@/lib/claude';
+
+// =============================================================================
+// Test Data
+// =============================================================================
+
+/**
+ * Create a mock speaker
+ */
+function createMockSpeaker(id: string, name: string): Speaker {
+  return { id, name };
+}
+
+/**
+ * Create a mock transcript segment
+ */
+function createMockSegment(
+  id: string,
+  startTime: number,
+  endTime: number,
+  speaker: Speaker,
+  text: string
+): TranscriptSegment {
+  return {
+    id,
+    startTime,
+    endTime,
+    speaker,
+    text,
+    confidence: 0.95,
+  };
+}
+
+/**
+ * Create a mock transcript
+ */
+function createMockTranscript(): Transcript {
+  const tanaka = createMockSpeaker('user-1', '田中');
+  const suzuki = createMockSpeaker('user-2', '鈴木');
+
+  return {
+    meetingId: 'meeting-123',
+    language: 'ja',
+    segments: [
+      createMockSegment('seg-1', 0, 15000, tanaka, 'おはようございます。本日の議題は新機能の開発についてです。'),
+      createMockSegment('seg-2', 15000, 30000, suzuki, 'はい、了解しました。まずスケジュールを確認しましょう。'),
+      createMockSegment('seg-3', 30000, 60000, tanaka, '来週金曜日をリリース日として決定しましょう。'),
+      createMockSegment('seg-4', 60000, 90000, suzuki, '承知しました。私がドキュメント作成を担当します。'),
+    ],
+    totalDuration: 90000,
+    createdAt: '2025-01-22T10:00:00.000Z',
+  };
+}
+
+/**
+ * Create a mock MinutesGenerationInput
+ */
+function createMockInput(): MinutesGenerationInput {
+  return {
+    transcript: createMockTranscript(),
+    meeting: {
+      id: 'meeting-123',
+      title: '週次定例会議',
+      date: '2025-01-22',
+      attendees: [
+        { id: 'user-1', name: '田中' },
+        { id: 'user-2', name: '鈴木' },
+      ],
+    },
+    options: {
+      language: 'ja',
+    },
+  };
+}
+
+/**
+ * Create a mock MinutesOutput (Claude API response)
+ */
+function createMockMinutesOutput(): MinutesOutput {
+  return {
+    summary: '本日の会議では新機能の開発スケジュールについて議論しました。来週金曜日をリリース日として決定し、鈴木さんがドキュメント作成を担当することになりました。',
+    topics: [
+      {
+        title: 'スケジュール確認',
+        startTime: 0,
+        endTime: 30000,
+        summary: '新機能開発のスケジュールを確認しました。',
+        keyPoints: ['本日の議題は新機能開発', 'スケジュール確認を優先'],
+        speakers: [{ name: '田中' }, { name: '鈴木' }],
+      },
+      {
+        title: 'リリース日決定',
+        startTime: 30000,
+        endTime: 90000,
+        summary: 'リリース日と担当を決定しました。',
+        keyPoints: ['来週金曜日がリリース日', '鈴木さんがドキュメント担当'],
+        speakers: [{ name: '田中' }, { name: '鈴木' }],
+      },
+    ],
+    decisions: [
+      {
+        content: '来週金曜日をリリース日とする',
+        context: 'スケジュール確認の結果、来週金曜日に決定',
+        decidedAt: 45000,
+      },
+    ],
+    actionItems: [
+      {
+        content: 'ドキュメント作成',
+        assignee: { name: '鈴木' },
+        dueDate: '2025-01-24',
+        priority: 'high',
+      },
+    ],
+    attendees: [{ name: '田中' }, { name: '鈴木' }],
+  };
+}
+
+// =============================================================================
+// Mock ClaudeClient
+// =============================================================================
+
+/**
+ * Create a mock ClaudeClient
+ */
+function createMockClaudeClient(output: MinutesOutput): ClaudeClient {
+  const mockClient = {
+    generateStructuredOutput: vi.fn().mockResolvedValue(output),
+    sendMessage: vi.fn(),
+  } as unknown as ClaudeClient;
+
+  return mockClient;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('MinutesGenerationService', () => {
+  let mockClient: ClaudeClient;
+  let service: MinutesGenerationService;
+
+  beforeEach(() => {
+    const mockOutput = createMockMinutesOutput();
+    mockClient = createMockClaudeClient(mockOutput);
+    service = createMinutesGenerationServiceWithClient(mockClient);
+  });
+
+  // ===========================================================================
+  // generateMinutes - Success Cases
+  // ===========================================================================
+
+  describe('generateMinutes', () => {
+    it('should generate minutes from transcript', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes).toBeDefined();
+      expect(result.minutes.summary).toContain('新機能');
+      expect(result.minutes.topics).toHaveLength(2);
+      expect(result.minutes.decisions).toHaveLength(1);
+      expect(result.minutes.actionItems).toHaveLength(1);
+      expect(result.processingTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should generate correct minutes ID format', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.id).toMatch(/^min_meeting-123_\d+$/);
+    });
+
+    it('should generate correct topic IDs', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.topics[0]?.id).toBe('topic_0');
+      expect(result.minutes.topics[1]?.id).toBe('topic_1');
+    });
+
+    it('should generate correct decision IDs', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.decisions[0]?.id).toBe('dec_0');
+    });
+
+    it('should generate correct action item IDs', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.actionItems[0]?.id).toBe('act_0');
+    });
+
+    it('should set action item status to pending', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.actionItems[0]?.status).toBe('pending');
+    });
+
+    it('should include metadata with model info', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.metadata).toBeDefined();
+      expect(result.minutes.metadata.model).toBe('claude-sonnet-4-20250514');
+      expect(result.minutes.metadata.generatedAt).toBeDefined();
+      expect(result.minutes.metadata.processingTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should calculate confidence score', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.metadata.confidence).toBeGreaterThan(0);
+      expect(result.minutes.metadata.confidence).toBeLessThanOrEqual(1);
+    });
+
+    it('should include usage information', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      expect(result.usage).toBeDefined();
+      expect(result.usage.inputTokens).toBeGreaterThan(0);
+      expect(result.usage.outputTokens).toBeGreaterThan(0);
+    });
+
+    it('should call ClaudeClient with correct parameters', async () => {
+      const input = createMockInput();
+
+      await service.generateMinutes(input);
+
+      expect(mockClient.generateStructuredOutput).toHaveBeenCalledTimes(1);
+      expect(mockClient.generateStructuredOutput).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: 'user',
+            content: expect.stringContaining('田中'),
+          }),
+        ]),
+        expect.any(Object),
+        expect.objectContaining({
+          maxTokens: 8000,
+          retryCount: 2,
+        })
+      );
+    });
+
+    it('should use custom maxTokens when provided', async () => {
+      const input = createMockInput();
+      input.options = { ...input.options, maxTokens: 16000 };
+
+      await service.generateMinutes(input);
+
+      expect(mockClient.generateStructuredOutput).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.any(Object),
+        expect.objectContaining({
+          maxTokens: 16000,
+        })
+      );
+    });
+
+    it('should use English system prompt when language is en', async () => {
+      const input = createMockInput();
+      input.options = { language: 'en' };
+
+      await service.generateMinutes(input);
+
+      expect(mockClient.generateStructuredOutput).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.any(Object),
+        expect.objectContaining({
+          system: expect.stringContaining('expert meeting minutes creator'),
+        })
+      );
+    });
+  });
+
+  // ===========================================================================
+  // formatTranscriptForPrompt - Tests
+  // ===========================================================================
+
+  describe('formatTranscriptForPrompt (via generateMinutes)', () => {
+    it('should format transcript with timestamps and speaker names', async () => {
+      const input = createMockInput();
+
+      await service.generateMinutes(input);
+
+      const mockFn = mockClient.generateStructuredOutput as ReturnType<typeof vi.fn>;
+      const callArgs = mockFn.mock.calls[0] as Array<Array<{ content: string }>>;
+      const promptContent = callArgs[0]?.[0]?.content ?? '';
+
+      expect(promptContent).toContain('[00:00:00]');
+      expect(promptContent).toContain('田中:');
+      expect(promptContent).toContain('[00:00:15]');
+      expect(promptContent).toContain('鈴木:');
+    });
+
+    it('should format timestamps correctly', async () => {
+      const input = createMockInput();
+
+      // Modify transcript to have longer timestamps
+      input.transcript = {
+        ...input.transcript,
+        segments: [
+          createMockSegment(
+            'seg-1',
+            3661000, // 1:01:01
+            3665000,
+            createMockSpeaker('user-1', '田中'),
+            'テスト'
+          ),
+        ],
+      };
+
+      await service.generateMinutes(input);
+
+      const mockFn = mockClient.generateStructuredOutput as ReturnType<typeof vi.fn>;
+      const callArgs = mockFn.mock.calls[0] as Array<Array<{ content: string }>>;
+      const promptContent = callArgs[0]?.[0]?.content ?? '';
+
+      expect(promptContent).toContain('[01:01:01]');
+    });
+  });
+
+  // ===========================================================================
+  // Input Validation - Tests
+  // ===========================================================================
+
+  describe('input validation', () => {
+    it('should throw error when transcript is missing', async () => {
+      const input = createMockInput();
+      // @ts-expect-error - Testing invalid input
+      input.transcript = undefined;
+
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        MinutesGenerationError
+      );
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        'Transcript is required'
+      );
+    });
+
+    it('should throw error when transcript has no segments', async () => {
+      const input = createMockInput();
+      input.transcript = {
+        ...input.transcript,
+        segments: [],
+      };
+
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        MinutesGenerationError
+      );
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        'at least one segment'
+      );
+    });
+
+    it('should throw error when meeting is missing', async () => {
+      const input = createMockInput();
+      // @ts-expect-error - Testing invalid input
+      input.meeting = undefined;
+
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        MinutesGenerationError
+      );
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        'Meeting information is required'
+      );
+    });
+
+    it('should throw error when meeting ID is empty', async () => {
+      const input = createMockInput();
+      input.meeting.id = '';
+
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        MinutesGenerationError
+      );
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        'Meeting ID is required'
+      );
+    });
+
+    it('should throw error when meeting title is empty', async () => {
+      const input = createMockInput();
+      input.meeting.title = '';
+
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        MinutesGenerationError
+      );
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        'Meeting title is required'
+      );
+    });
+
+    it('should throw error when meeting date is invalid format', async () => {
+      const input = createMockInput();
+      input.meeting.date = '22-01-2025'; // Wrong format
+
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        MinutesGenerationError
+      );
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        'YYYY-MM-DD format'
+      );
+    });
+
+    it('should throw error when attendees is not an array', async () => {
+      const input = createMockInput();
+      // @ts-expect-error - Testing invalid input
+      input.meeting.attendees = 'invalid';
+
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        MinutesGenerationError
+      );
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        'must be an array'
+      );
+    });
+  });
+
+  // ===========================================================================
+  // Error Handling - Tests
+  // ===========================================================================
+
+  describe('error handling', () => {
+    it('should wrap ClaudeApiError in MinutesGenerationError', async () => {
+      const input = createMockInput();
+      const apiError = new ClaudeApiError('API rate limit exceeded', 429);
+
+      (mockClient.generateStructuredOutput as ReturnType<typeof vi.fn>).mockRejectedValue(
+        apiError
+      );
+
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        MinutesGenerationError
+      );
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        'Claude API error'
+      );
+    });
+
+    it('should set correct error code for API errors', async () => {
+      const input = createMockInput();
+      const apiError = new ClaudeApiError('API error');
+
+      (mockClient.generateStructuredOutput as ReturnType<typeof vi.fn>).mockRejectedValue(
+        apiError
+      );
+
+      try {
+        await service.generateMinutes(input);
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MinutesGenerationError);
+        expect((error as MinutesGenerationError).code).toBe('CLAUDE_API_ERROR');
+      }
+    });
+
+    it('should wrap ClaudeParseError in MinutesGenerationError', async () => {
+      const input = createMockInput();
+      const parseError = new ClaudeParseError('Invalid JSON', 'raw content');
+
+      (mockClient.generateStructuredOutput as ReturnType<typeof vi.fn>).mockRejectedValue(
+        parseError
+      );
+
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        MinutesGenerationError
+      );
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        'parse Claude response'
+      );
+    });
+
+    it('should set correct error code for parse errors', async () => {
+      const input = createMockInput();
+      const parseError = new ClaudeParseError('Parse error');
+
+      (mockClient.generateStructuredOutput as ReturnType<typeof vi.fn>).mockRejectedValue(
+        parseError
+      );
+
+      try {
+        await service.generateMinutes(input);
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MinutesGenerationError);
+        expect((error as MinutesGenerationError).code).toBe('PARSE_ERROR');
+      }
+    });
+
+    it('should handle unexpected errors', async () => {
+      const input = createMockInput();
+      const unexpectedError = new Error('Network failure');
+
+      (mockClient.generateStructuredOutput as ReturnType<typeof vi.fn>).mockRejectedValue(
+        unexpectedError
+      );
+
+      await expect(service.generateMinutes(input)).rejects.toThrow(
+        MinutesGenerationError
+      );
+    });
+
+    it('should set UNKNOWN_ERROR code for unexpected errors', async () => {
+      const input = createMockInput();
+      const unexpectedError = new Error('Something went wrong');
+
+      (mockClient.generateStructuredOutput as ReturnType<typeof vi.fn>).mockRejectedValue(
+        unexpectedError
+      );
+
+      try {
+        await service.generateMinutes(input);
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(MinutesGenerationError);
+        expect((error as MinutesGenerationError).code).toBe('UNKNOWN_ERROR');
+      }
+    });
+  });
+
+  // ===========================================================================
+  // Transformation - Tests
+  // ===========================================================================
+
+  describe('transformation', () => {
+    it('should transform attendees with generated IDs', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.attendees).toHaveLength(2);
+      expect(result.minutes.attendees[0]?.id).toBe('speaker_0');
+      expect(result.minutes.attendees[0]?.name).toBe('田中');
+    });
+
+    it('should transform topic speakers with IDs', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      const firstTopic = result.minutes.topics[0];
+      expect(firstTopic?.speakers).toHaveLength(2);
+      expect(firstTopic?.speakers[0]?.id).toBe('speaker_0');
+    });
+
+    it('should transform action item with assignee', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      const firstAction = result.minutes.actionItems[0];
+      expect(firstAction?.assignee).toBeDefined();
+      expect(firstAction?.assignee?.id).toBe('assignee_0');
+      expect(firstAction?.assignee?.name).toBe('鈴木');
+    });
+
+    it('should preserve due date in action items', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.actionItems[0]?.dueDate).toBe('2025-01-24');
+    });
+
+    it('should calculate duration from topics', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      // Topics span from 0 to 90000
+      expect(result.minutes.duration).toBe(90000);
+    });
+
+    it('should handle empty decisions array', async () => {
+      const emptyOutput: MinutesOutput = {
+        ...createMockMinutesOutput(),
+        decisions: [],
+      };
+      mockClient = createMockClaudeClient(emptyOutput);
+      service = createMinutesGenerationServiceWithClient(mockClient);
+
+      const input = createMockInput();
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.decisions).toHaveLength(0);
+    });
+
+    it('should handle empty action items array', async () => {
+      const emptyOutput: MinutesOutput = {
+        ...createMockMinutesOutput(),
+        actionItems: [],
+      };
+      mockClient = createMockClaudeClient(emptyOutput);
+      service = createMinutesGenerationServiceWithClient(mockClient);
+
+      const input = createMockInput();
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.actionItems).toHaveLength(0);
+    });
+
+    it('should handle missing attendees in output', async () => {
+      const noAttendeesOutput: MinutesOutput = {
+        ...createMockMinutesOutput(),
+        attendees: undefined,
+      };
+      mockClient = createMockClaudeClient(noAttendeesOutput);
+      service = createMinutesGenerationServiceWithClient(mockClient);
+
+      const input = createMockInput();
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.attendees).toHaveLength(0);
+    });
+
+    it('should handle action item without assignee', async () => {
+      const outputWithNoAssignee: MinutesOutput = {
+        ...createMockMinutesOutput(),
+        actionItems: [
+          {
+            content: 'タスク',
+            priority: 'medium',
+          },
+        ],
+      };
+      mockClient = createMockClaudeClient(outputWithNoAssignee);
+      service = createMinutesGenerationServiceWithClient(mockClient);
+
+      const input = createMockInput();
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.actionItems[0]?.assignee).toBeUndefined();
+    });
+
+    it('should handle action item without due date', async () => {
+      const outputWithNoDueDate: MinutesOutput = {
+        ...createMockMinutesOutput(),
+        actionItems: [
+          {
+            content: 'タスク',
+            assignee: { name: '田中' },
+            priority: 'high',
+          },
+        ],
+      };
+      mockClient = createMockClaudeClient(outputWithNoDueDate);
+      service = createMinutesGenerationServiceWithClient(mockClient);
+
+      const input = createMockInput();
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.actionItems[0]?.dueDate).toBeUndefined();
+    });
+  });
+
+  // ===========================================================================
+  // Confidence Calculation - Tests
+  // ===========================================================================
+
+  describe('confidence calculation', () => {
+    it('should give high confidence for complete output', async () => {
+      const input = createMockInput();
+
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.metadata.confidence).toBeGreaterThan(0.7);
+    });
+
+    it('should give lower confidence for minimal output', async () => {
+      const minimalOutput: MinutesOutput = {
+        summary: 'Short',
+        topics: [],
+        decisions: [],
+        actionItems: [],
+      };
+      mockClient = createMockClaudeClient(minimalOutput);
+      service = createMinutesGenerationServiceWithClient(mockClient);
+
+      const input = createMockInput();
+      const result = await service.generateMinutes(input);
+
+      expect(result.minutes.metadata.confidence).toBeLessThan(0.5);
+    });
+  });
+});
+
+// =============================================================================
+// Factory Function Tests
+// =============================================================================
+
+describe('createMinutesGenerationService', () => {
+  it('should be exported from module', async () => {
+    const { createMinutesGenerationService } = await import(
+      '../minutes-generation.service'
+    );
+    expect(createMinutesGenerationService).toBeDefined();
+  });
+});
+
+describe('MinutesGenerationError', () => {
+  it('should have correct name property', () => {
+    const error = new MinutesGenerationError('test', 'TEST_CODE');
+    expect(error.name).toBe('MinutesGenerationError');
+  });
+
+  it('should preserve error code', () => {
+    const error = new MinutesGenerationError('test', 'TEST_CODE');
+    expect(error.code).toBe('TEST_CODE');
+  });
+
+  it('should preserve cause', () => {
+    const cause = new Error('original');
+    const error = new MinutesGenerationError('test', 'TEST_CODE', cause);
+    expect(error.cause).toBe(cause);
+  });
+
+  it('should be instanceof Error', () => {
+    const error = new MinutesGenerationError('test', 'TEST_CODE');
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('should be instanceof MinutesGenerationError', () => {
+    const error = new MinutesGenerationError('test', 'TEST_CODE');
+    expect(error).toBeInstanceOf(MinutesGenerationError);
+  });
+});

--- a/src/services/minutes-generation.service.ts
+++ b/src/services/minutes-generation.service.ts
@@ -1,0 +1,639 @@
+/**
+ * MinutesGenerationService - AI-powered meeting minutes generation
+ * @module services/minutes-generation.service
+ *
+ * Generates structured meeting minutes from transcript data using Claude AI.
+ */
+
+import {
+  ClaudeClient,
+  ClaudeApiError,
+  ClaudeParseError,
+  buildMinutesGenerationPrompt,
+  getSystemPrompt,
+  minutesOutputSchema,
+  DEFAULT_MODEL,
+  type MinutesOutput,
+  type MinutesOutputSpeaker,
+} from '@/lib/claude';
+import type { Transcript, TranscriptSegment } from '@/types/transcript';
+import type {
+  Minutes,
+  Speaker,
+  TopicSegment,
+  DecisionItem,
+  ActionItem,
+} from '@/types/minutes';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Default max tokens for minutes generation
+ */
+const DEFAULT_GENERATION_MAX_TOKENS = 8000;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Input for minutes generation
+ */
+export interface MinutesGenerationInput {
+  /** Transcript data */
+  transcript: Transcript;
+  /** Meeting information */
+  meeting: {
+    /** Meeting ID */
+    id: string;
+    /** Meeting title */
+    title: string;
+    /** Meeting date in ISO format (YYYY-MM-DD) */
+    date: string;
+    /** Meeting attendees */
+    attendees: Array<{ id: string; name: string }>;
+  };
+  /** Generation options */
+  options?: {
+    /** Output language */
+    language?: 'ja' | 'en';
+    /** Max tokens for generation */
+    maxTokens?: number;
+  };
+}
+
+/**
+ * Result of minutes generation
+ */
+export interface MinutesGenerationResult {
+  /** Generated minutes */
+  minutes: Minutes;
+  /** Processing time in milliseconds */
+  processingTimeMs: number;
+  /** Token usage */
+  usage: {
+    /** Input tokens */
+    inputTokens: number;
+    /** Output tokens */
+    outputTokens: number;
+  };
+}
+
+// =============================================================================
+// Error Classes
+// =============================================================================
+
+/**
+ * Error thrown when minutes generation fails
+ */
+export class MinutesGenerationError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'MinutesGenerationError';
+    Object.setPrototypeOf(this, MinutesGenerationError.prototype);
+  }
+}
+
+// =============================================================================
+// MinutesGenerationService Class
+// =============================================================================
+
+/**
+ * Service for generating meeting minutes from transcripts using Claude AI
+ *
+ * @example
+ * ```typescript
+ * const service = createMinutesGenerationService();
+ *
+ * const result = await service.generateMinutes({
+ *   transcript: transcriptData,
+ *   meeting: {
+ *     id: 'meeting-123',
+ *     title: 'Weekly Standup',
+ *     date: '2025-01-22',
+ *     attendees: [
+ *       { id: 'user-1', name: 'Tanaka' },
+ *       { id: 'user-2', name: 'Suzuki' },
+ *     ],
+ *   },
+ *   options: { language: 'ja' },
+ * });
+ *
+ * console.log(result.minutes.summary);
+ * console.log(`Generated in ${result.processingTimeMs}ms`);
+ * ```
+ */
+export class MinutesGenerationService {
+  constructor(private readonly claudeClient: ClaudeClient) {}
+
+  /**
+   * Generate meeting minutes from transcript
+   *
+   * @param input - Generation input containing transcript and meeting info
+   * @returns Generated minutes with processing metrics
+   * @throws {MinutesGenerationError} When generation fails
+   */
+  async generateMinutes(
+    input: MinutesGenerationInput
+  ): Promise<MinutesGenerationResult> {
+    const startTime = Date.now();
+
+    // Validate input
+    this.validateInput(input);
+
+    const { transcript, meeting, options } = input;
+    const language = options?.language ?? 'ja';
+    const maxTokens = options?.maxTokens ?? DEFAULT_GENERATION_MAX_TOKENS;
+
+    try {
+      // Format transcript for prompt
+      const transcriptText = this.formatTranscriptForPrompt(transcript);
+
+      // Build prompt
+      const userPrompt = buildMinutesGenerationPrompt({
+        transcript: transcriptText,
+        meetingTitle: meeting.title,
+        meetingDate: meeting.date,
+        attendees: meeting.attendees.map((a) => a.name),
+        language,
+      });
+
+      // Get system prompt
+      const systemPrompt = getSystemPrompt(language);
+
+      // Call Claude API with structured output
+      const output = await this.claudeClient.generateStructuredOutput(
+        [{ role: 'user', content: userPrompt }],
+        minutesOutputSchema,
+        {
+          system: systemPrompt,
+          maxTokens,
+          retryCount: 2,
+        }
+      );
+
+      const processingTimeMs = Date.now() - startTime;
+
+      // Transform to Minutes type
+      const minutes = this.transformToMinutes(output, meeting.id, processingTimeMs);
+
+      return {
+        minutes,
+        processingTimeMs,
+        usage: {
+          // Note: ClaudeClient doesn't expose token usage in current implementation
+          // These are estimates based on typical usage
+          inputTokens: this.estimateTokens(userPrompt + systemPrompt),
+          outputTokens: this.estimateTokens(JSON.stringify(output)),
+        },
+      };
+    } catch (error) {
+      if (error instanceof ClaudeApiError) {
+        throw new MinutesGenerationError(
+          `Claude API error: ${error.message}`,
+          'CLAUDE_API_ERROR',
+          error
+        );
+      }
+
+      if (error instanceof ClaudeParseError) {
+        throw new MinutesGenerationError(
+          `Failed to parse Claude response: ${error.message}`,
+          'PARSE_ERROR',
+          error
+        );
+      }
+
+      if (error instanceof MinutesGenerationError) {
+        throw error;
+      }
+
+      throw new MinutesGenerationError(
+        `Unexpected error during minutes generation: ${error instanceof Error ? error.message : String(error)}`,
+        'UNKNOWN_ERROR',
+        error
+      );
+    }
+  }
+
+  /**
+   * Format transcript data as text for prompt
+   *
+   * Converts Transcript object to a text format suitable for the AI prompt:
+   * [HH:MM:SS] SpeakerName: Text content
+   *
+   * @param transcript - Transcript data to format
+   * @returns Formatted transcript text
+   */
+  private formatTranscriptForPrompt(transcript: Transcript): string {
+    if (transcript.segments.length === 0) {
+      return '';
+    }
+
+    return transcript.segments
+      .map((segment) => this.formatSegment(segment))
+      .join('\n');
+  }
+
+  /**
+   * Format a single transcript segment
+   *
+   * @param segment - Segment to format
+   * @returns Formatted segment string "[HH:MM:SS] Speaker: Text"
+   */
+  private formatSegment(segment: TranscriptSegment): string {
+    const timestamp = this.formatTimestamp(segment.startTime);
+    return `[${timestamp}] ${segment.speaker.name}: ${segment.text}`;
+  }
+
+  /**
+   * Format milliseconds to HH:MM:SS timestamp
+   *
+   * @param ms - Time in milliseconds
+   * @returns Formatted timestamp string
+   */
+  private formatTimestamp(ms: number): string {
+    if (ms < 0) {
+      return '00:00:00';
+    }
+
+    const totalSeconds = Math.floor(ms / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    const pad = (n: number): string => n.toString().padStart(2, '0');
+
+    return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+  }
+
+  /**
+   * Transform Claude output to Minutes type
+   *
+   * Adds server-generated IDs and metadata to the AI output.
+   *
+   * @param output - Claude AI output
+   * @param meetingId - Meeting ID for reference
+   * @param processingTimeMs - Processing time for metadata
+   * @returns Complete Minutes object
+   */
+  private transformToMinutes(
+    output: MinutesOutput,
+    meetingId: string,
+    processingTimeMs: number
+  ): Minutes {
+    const timestamp = Date.now();
+    const now = new Date();
+
+    // Generate minutes ID
+    const minutesId = `min_${meetingId}_${timestamp}`;
+
+    // Transform attendees
+    const attendees = this.transformAttendees(output.attendees ?? []);
+
+    // Transform topics
+    const topics = output.topics.map((topic, index) =>
+      this.transformTopic(topic, index)
+    );
+
+    // Transform decisions
+    const decisions = output.decisions.map((decision, index) =>
+      this.transformDecision(decision, index)
+    );
+
+    // Transform action items
+    const actionItems = output.actionItems.map((item, index) =>
+      this.transformActionItem(item, index)
+    );
+
+    // Calculate total duration from topics
+    const duration = this.calculateDuration(topics);
+
+    // Extract date from now if not available
+    const dateStr = now.toISOString().split('T')[0] ?? '1970-01-01';
+
+    return {
+      id: minutesId,
+      meetingId,
+      title: '', // Will be set by caller
+      date: dateStr,
+      duration,
+      summary: output.summary,
+      topics,
+      decisions,
+      actionItems,
+      attendees,
+      metadata: {
+        generatedAt: now.toISOString(),
+        model: DEFAULT_MODEL,
+        processingTimeMs,
+        confidence: this.calculateConfidence(output),
+      },
+    };
+  }
+
+  /**
+   * Transform AI output speakers to Speaker type
+   *
+   * @param speakers - AI output speakers
+   * @returns Speaker array with generated IDs
+   */
+  private transformAttendees(speakers: MinutesOutputSpeaker[]): Speaker[] {
+    return speakers.map((speaker, index) => {
+      const base: Speaker = {
+        id: `speaker_${index}`,
+        name: speaker.name,
+      };
+
+      if (speaker.larkUserId !== undefined) {
+        return { ...base, larkUserId: speaker.larkUserId };
+      }
+
+      return base;
+    });
+  }
+
+  /**
+   * Transform AI output topic to TopicSegment type
+   *
+   * @param topic - AI output topic
+   * @param index - Topic index for ID generation
+   * @returns TopicSegment with generated ID
+   */
+  private transformTopic(
+    topic: MinutesOutput['topics'][number],
+    index: number
+  ): TopicSegment {
+    const speakers = (topic.speakers ?? []).map((speaker, speakerIndex) => {
+      const base: Speaker = {
+        id: `speaker_${speakerIndex}`,
+        name: speaker.name,
+      };
+
+      if (speaker.larkUserId !== undefined) {
+        return { ...base, larkUserId: speaker.larkUserId };
+      }
+
+      return base;
+    });
+
+    return {
+      id: `topic_${index}`,
+      title: topic.title,
+      startTime: topic.startTime,
+      endTime: topic.endTime,
+      summary: topic.summary,
+      keyPoints: topic.keyPoints,
+      speakers,
+    };
+  }
+
+  /**
+   * Transform AI output decision to DecisionItem type
+   *
+   * @param decision - AI output decision
+   * @param index - Decision index for ID generation
+   * @returns DecisionItem with generated ID
+   */
+  private transformDecision(
+    decision: MinutesOutput['decisions'][number],
+    index: number
+  ): DecisionItem {
+    return {
+      id: `dec_${index}`,
+      content: decision.content,
+      context: decision.context,
+      decidedAt: decision.decidedAt,
+    };
+  }
+
+  /**
+   * Transform AI output action item to ActionItem type
+   *
+   * @param item - AI output action item
+   * @param index - Action item index for ID generation
+   * @returns ActionItem with generated ID
+   */
+  private transformActionItem(
+    item: MinutesOutput['actionItems'][number],
+    index: number
+  ): ActionItem {
+    const base: ActionItem = {
+      id: `act_${index}`,
+      content: item.content,
+      priority: item.priority,
+      status: 'pending',
+    };
+
+    // Build result with optional fields
+    let result = base;
+
+    if (item.assignee !== undefined) {
+      const assignee: Speaker = {
+        id: `assignee_${index}`,
+        name: item.assignee.name,
+      };
+
+      if (item.assignee.larkUserId !== undefined) {
+        result = {
+          ...result,
+          assignee: { ...assignee, larkUserId: item.assignee.larkUserId },
+        };
+      } else {
+        result = { ...result, assignee };
+      }
+    }
+
+    if (item.dueDate !== undefined) {
+      result = { ...result, dueDate: item.dueDate };
+    }
+
+    return result;
+  }
+
+  /**
+   * Calculate total duration from topics
+   *
+   * @param topics - Array of topic segments
+   * @returns Total duration in milliseconds
+   */
+  private calculateDuration(topics: TopicSegment[]): number {
+    if (topics.length === 0) {
+      return 0;
+    }
+
+    const maxEndTime = Math.max(...topics.map((t) => t.endTime));
+    const minStartTime = Math.min(...topics.map((t) => t.startTime));
+
+    return maxEndTime - minStartTime;
+  }
+
+  /**
+   * Calculate confidence score based on output completeness
+   *
+   * @param output - AI output to evaluate
+   * @returns Confidence score between 0 and 1
+   */
+  private calculateConfidence(output: MinutesOutput): number {
+    let score = 0;
+    let factors = 0;
+
+    // Summary present and substantial
+    if (output.summary.length > 50) {
+      score += 1;
+    } else if (output.summary.length > 0) {
+      score += 0.5;
+    }
+    factors++;
+
+    // Topics present
+    if (output.topics.length > 0) {
+      score += 1;
+      // Topics have key points
+      const topicsWithKeyPoints = output.topics.filter(
+        (t) => t.keyPoints.length > 0
+      );
+      if (topicsWithKeyPoints.length === output.topics.length) {
+        score += 0.5;
+      }
+    }
+    factors += 1.5;
+
+    // Decisions and actions (optional, so partial credit)
+    if (output.decisions.length > 0 || output.actionItems.length > 0) {
+      score += 0.5;
+    }
+    factors += 0.5;
+
+    return Math.min(1, score / factors);
+  }
+
+  /**
+   * Estimate token count from text
+   *
+   * Simple estimation: ~4 characters per token for mixed content
+   *
+   * @param text - Text to estimate
+   * @returns Estimated token count
+   */
+  private estimateTokens(text: string): number {
+    return Math.ceil(text.length / 4);
+  }
+
+  /**
+   * Validate generation input
+   *
+   * @param input - Input to validate
+   * @throws {MinutesGenerationError} When input is invalid
+   */
+  private validateInput(input: MinutesGenerationInput): void {
+    const { transcript, meeting } = input;
+
+    if (transcript === undefined || transcript === null) {
+      throw new MinutesGenerationError(
+        'Transcript is required',
+        'INVALID_INPUT'
+      );
+    }
+
+    if (transcript.segments.length === 0) {
+      throw new MinutesGenerationError(
+        'Transcript must have at least one segment',
+        'INVALID_INPUT'
+      );
+    }
+
+    if (meeting === undefined || meeting === null) {
+      throw new MinutesGenerationError(
+        'Meeting information is required',
+        'INVALID_INPUT'
+      );
+    }
+
+    if (meeting.id === '' || meeting.id.trim() === '') {
+      throw new MinutesGenerationError(
+        'Meeting ID is required',
+        'INVALID_INPUT'
+      );
+    }
+
+    if (meeting.title === '' || meeting.title.trim() === '') {
+      throw new MinutesGenerationError(
+        'Meeting title is required',
+        'INVALID_INPUT'
+      );
+    }
+
+    if (meeting.date === '' || !/^\d{4}-\d{2}-\d{2}$/.test(meeting.date)) {
+      throw new MinutesGenerationError(
+        'Meeting date is required and must be in YYYY-MM-DD format',
+        'INVALID_INPUT'
+      );
+    }
+
+    if (!Array.isArray(meeting.attendees)) {
+      throw new MinutesGenerationError(
+        'Meeting attendees must be an array',
+        'INVALID_INPUT'
+      );
+    }
+  }
+}
+
+// =============================================================================
+// Factory Functions
+// =============================================================================
+
+/**
+ * Create a MinutesGenerationService instance with default configuration
+ *
+ * Uses ANTHROPIC_API_KEY environment variable for authentication.
+ *
+ * @returns MinutesGenerationService instance
+ * @throws {MinutesGenerationError} When API key is not configured
+ *
+ * @example
+ * ```typescript
+ * const service = createMinutesGenerationService();
+ * const result = await service.generateMinutes(input);
+ * ```
+ */
+export function createMinutesGenerationService(): MinutesGenerationService {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+
+  if (apiKey === undefined || apiKey === '' || apiKey.trim() === '') {
+    throw new MinutesGenerationError(
+      'ANTHROPIC_API_KEY environment variable is required',
+      'MISSING_API_KEY'
+    );
+  }
+
+  const claudeClient = new ClaudeClient(apiKey);
+  return new MinutesGenerationService(claudeClient);
+}
+
+/**
+ * Create a MinutesGenerationService instance with custom ClaudeClient
+ *
+ * Useful for testing or custom configurations.
+ *
+ * @param claudeClient - Custom ClaudeClient instance
+ * @returns MinutesGenerationService instance
+ *
+ * @example
+ * ```typescript
+ * const customClient = new ClaudeClient(apiKey, { maxTokens: 16000 });
+ * const service = createMinutesGenerationServiceWithClient(customClient);
+ * ```
+ */
+export function createMinutesGenerationServiceWithClient(
+  claudeClient: ClaudeClient
+): MinutesGenerationService {
+  return new MinutesGenerationService(claudeClient);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,3 +7,53 @@ export * from './auth';
 export * from './lark';
 export * from './meeting';
 export * from './transcript';
+
+// Minutes types - exported with namespace to avoid Speaker collision with transcript
+export {
+  // Zod Schemas
+  SpeakerSchema as MinutesSpeakerSchema,
+  TopicSegmentSchema,
+  DecisionItemSchema,
+  ActionItemSchema,
+  MinutesMetadataSchema,
+  MinutesSchema,
+  PrioritySchema,
+  ActionItemStatusSchema,
+  // Types
+  type Speaker as MinutesSpeaker,
+  type TopicSegment,
+  type DecisionItem,
+  type ActionItem,
+  type Minutes,
+  type MinutesMetadata,
+  type Priority,
+  type ActionItemStatus,
+  type ReadonlySpeaker as ReadonlyMinutesSpeaker,
+  type ReadonlyTopicSegment,
+  type ReadonlyDecisionItem,
+  type ReadonlyActionItem,
+  type ReadonlyMinutesMetadata,
+  type ReadonlyMinutes,
+  // Utility functions
+  generateId,
+  createEmptyMinutes,
+  minutesToMarkdown,
+  filterActionItemsByStatus,
+  sortActionItemsByPriority,
+  getActionItemsByAssignee,
+  getTotalTopicsDuration,
+  findTopicById,
+  getDecisionsByTopicId,
+  getActionItemsByTopicId,
+  calculateCompletionPercentage,
+  createSpeaker as createMinutesSpeaker,
+  createActionItem,
+  createDecisionItem,
+  createTopicSegment,
+  // Validation functions
+  validateMinutes,
+  validateActionItem,
+  validateTopicSegment,
+  validateSpeaker as validateMinutesSpeaker,
+  validateDecisionItem,
+} from './minutes';

--- a/src/types/minutes.ts
+++ b/src/types/minutes.ts
@@ -1,0 +1,758 @@
+/**
+ * Minutes (AI-generated meeting minutes) type definitions
+ * @module types/minutes
+ */
+
+import { z } from 'zod';
+
+// ============================================================================
+// Zod Schemas
+// ============================================================================
+
+/**
+ * Zod schema for Speaker information
+ */
+export const SpeakerSchema = z.object({
+  /** Unique speaker identifier */
+  id: z.string().min(1),
+  /** Speaker display name */
+  name: z.string().min(1),
+  /** Lark user ID for integration (optional) */
+  larkUserId: z.string().optional(),
+});
+
+/**
+ * Zod schema for TopicSegment
+ */
+export const TopicSegmentSchema = z.object({
+  /** Unique segment identifier */
+  id: z.string().min(1),
+  /** Topic title */
+  title: z.string().min(1),
+  /** Start time in milliseconds from meeting start */
+  startTime: z.number().int().nonnegative(),
+  /** End time in milliseconds from meeting start */
+  endTime: z.number().int().nonnegative(),
+  /** AI-generated summary of the topic */
+  summary: z.string(),
+  /** Key points discussed */
+  keyPoints: z.array(z.string()),
+  /** Speakers who participated in this topic */
+  speakers: z.array(SpeakerSchema),
+}).refine((data) => data.endTime >= data.startTime, {
+  message: 'endTime must be greater than or equal to startTime',
+  path: ['endTime'],
+});
+
+/**
+ * Zod schema for DecisionItem
+ */
+export const DecisionItemSchema = z.object({
+  /** Unique decision identifier */
+  id: z.string().min(1),
+  /** Decision content */
+  content: z.string().min(1),
+  /** Background or reasoning for the decision */
+  context: z.string(),
+  /** Time when decision was made (milliseconds) */
+  decidedAt: z.number().int().nonnegative(),
+  /** Related topic segment ID (optional) */
+  relatedTopicId: z.string().optional(),
+});
+
+/**
+ * Priority level for action items
+ */
+export const PrioritySchema = z.enum(['high', 'medium', 'low']);
+
+/**
+ * Status of action items
+ */
+export const ActionItemStatusSchema = z.enum(['pending', 'in_progress', 'completed']);
+
+/**
+ * Zod schema for ActionItem
+ */
+export const ActionItemSchema = z.object({
+  /** Unique action item identifier */
+  id: z.string().min(1),
+  /** Task content */
+  content: z.string().min(1),
+  /** Assigned person (optional) */
+  assignee: SpeakerSchema.optional(),
+  /** Due date in ISO format (optional) */
+  dueDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be ISO date format YYYY-MM-DD').optional(),
+  /** Priority level */
+  priority: PrioritySchema,
+  /** Current status */
+  status: ActionItemStatusSchema,
+  /** Related topic segment ID (optional) */
+  relatedTopicId: z.string().optional(),
+});
+
+/**
+ * Zod schema for MinutesMetadata
+ */
+export const MinutesMetadataSchema = z.object({
+  /** Generation timestamp in ISO format */
+  generatedAt: z.string().datetime({ offset: true }),
+  /** AI model used for generation */
+  model: z.string().min(1),
+  /** Processing time in milliseconds */
+  processingTimeMs: z.number().int().nonnegative(),
+  /** Confidence score (0-1) */
+  confidence: z.number().min(0).max(1),
+});
+
+/**
+ * Zod schema for Minutes (complete meeting minutes)
+ */
+export const MinutesSchema = z.object({
+  /** Unique minutes identifier */
+  id: z.string().min(1),
+  /** Associated meeting identifier */
+  meetingId: z.string().min(1),
+  /** Meeting title */
+  title: z.string().min(1),
+  /** Meeting date in ISO format */
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  /** Meeting duration in milliseconds */
+  duration: z.number().int().nonnegative(),
+  /** Overall meeting summary (3-5 sentences) */
+  summary: z.string(),
+  /** Topic segments */
+  topics: z.array(TopicSegmentSchema),
+  /** Decision items */
+  decisions: z.array(DecisionItemSchema),
+  /** Action items */
+  actionItems: z.array(ActionItemSchema),
+  /** Meeting attendees */
+  attendees: z.array(SpeakerSchema),
+  /** Generation metadata */
+  metadata: MinutesMetadataSchema,
+});
+
+// ============================================================================
+// Core Types (inferred from Zod schemas)
+// ============================================================================
+
+/**
+ * Speaker information in meeting minutes
+ */
+export type Speaker = z.infer<typeof SpeakerSchema>;
+
+/**
+ * A topic segment representing a discussion topic within the meeting
+ */
+export type TopicSegment = z.infer<typeof TopicSegmentSchema>;
+
+/**
+ * A decision made during the meeting
+ */
+export type DecisionItem = z.infer<typeof DecisionItemSchema>;
+
+/**
+ * Priority level for action items
+ */
+export type Priority = z.infer<typeof PrioritySchema>;
+
+/**
+ * Status of an action item
+ */
+export type ActionItemStatus = z.infer<typeof ActionItemStatusSchema>;
+
+/**
+ * An action item or task assigned during the meeting
+ */
+export type ActionItem = z.infer<typeof ActionItemSchema>;
+
+/**
+ * Metadata about the AI-generated minutes
+ */
+export type MinutesMetadata = z.infer<typeof MinutesMetadataSchema>;
+
+/**
+ * Complete AI-generated meeting minutes
+ */
+export type Minutes = z.infer<typeof MinutesSchema>;
+
+// ============================================================================
+// Read-only Types (for immutable usage)
+// ============================================================================
+
+/**
+ * Read-only Speaker type
+ */
+export interface ReadonlySpeaker {
+  readonly id: string;
+  readonly name: string;
+  readonly larkUserId?: string | undefined;
+}
+
+/**
+ * Read-only TopicSegment type
+ */
+export interface ReadonlyTopicSegment {
+  readonly id: string;
+  readonly title: string;
+  readonly startTime: number;
+  readonly endTime: number;
+  readonly summary: string;
+  readonly keyPoints: readonly string[];
+  readonly speakers: readonly ReadonlySpeaker[];
+}
+
+/**
+ * Read-only DecisionItem type
+ */
+export interface ReadonlyDecisionItem {
+  readonly id: string;
+  readonly content: string;
+  readonly context: string;
+  readonly decidedAt: number;
+  readonly relatedTopicId?: string | undefined;
+}
+
+/**
+ * Read-only ActionItem type
+ */
+export interface ReadonlyActionItem {
+  readonly id: string;
+  readonly content: string;
+  readonly assignee?: ReadonlySpeaker | undefined;
+  readonly dueDate?: string | undefined;
+  readonly priority: Priority;
+  readonly status: ActionItemStatus;
+  readonly relatedTopicId?: string | undefined;
+}
+
+/**
+ * Read-only MinutesMetadata type
+ */
+export interface ReadonlyMinutesMetadata {
+  readonly generatedAt: string;
+  readonly model: string;
+  readonly processingTimeMs: number;
+  readonly confidence: number;
+}
+
+/**
+ * Read-only Minutes type
+ */
+export interface ReadonlyMinutes {
+  readonly id: string;
+  readonly meetingId: string;
+  readonly title: string;
+  readonly date: string;
+  readonly duration: number;
+  readonly summary: string;
+  readonly topics: readonly ReadonlyTopicSegment[];
+  readonly decisions: readonly ReadonlyDecisionItem[];
+  readonly actionItems: readonly ReadonlyActionItem[];
+  readonly attendees: readonly ReadonlySpeaker[];
+  readonly metadata: ReadonlyMinutesMetadata;
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Generate a unique ID for minutes-related entities
+ *
+ * @param prefix - Prefix for the ID (e.g., 'min', 'topic', 'action')
+ * @returns A unique identifier string
+ */
+export function generateId(prefix: string): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).substring(2, 8);
+  return `${prefix}_${timestamp}_${random}`;
+}
+
+/**
+ * Create an empty Minutes object with default values
+ *
+ * @param meetingId - The associated meeting ID
+ * @param title - Optional title for the minutes
+ * @returns A new Minutes object with empty/default values
+ *
+ * @example
+ * ```typescript
+ * const minutes = createEmptyMinutes('meeting-123');
+ * // minutes.id = 'min_xxxxx'
+ * // minutes.topics = []
+ * // minutes.decisions = []
+ * // minutes.actionItems = []
+ * ```
+ */
+export function createEmptyMinutes(meetingId: string, title?: string): Minutes {
+  const now = new Date();
+  const dateStr = now.toISOString().split('T')[0];
+  return {
+    id: generateId('min'),
+    meetingId,
+    title: title ?? 'Untitled Meeting',
+    date: dateStr ?? '1970-01-01',
+    duration: 0,
+    summary: '',
+    topics: [],
+    decisions: [],
+    actionItems: [],
+    attendees: [],
+    metadata: {
+      generatedAt: now.toISOString(),
+      model: 'unknown',
+      processingTimeMs: 0,
+      confidence: 0,
+    },
+  };
+}
+
+/**
+ * Format duration in milliseconds to human-readable string
+ *
+ * @param ms - Duration in milliseconds
+ * @returns Formatted string (e.g., "1h 30m", "45m", "2h")
+ */
+function formatDuration(ms: number): string {
+  const totalMinutes = Math.floor(ms / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0 && minutes > 0) {
+    return `${hours}h ${minutes}m`;
+  } else if (hours > 0) {
+    return `${hours}h`;
+  } else if (minutes > 0) {
+    return `${minutes}m`;
+  } else {
+    return '0m';
+  }
+}
+
+/**
+ * Format timestamp in milliseconds to MM:SS or HH:MM:SS format
+ *
+ * @param ms - Time in milliseconds
+ * @returns Formatted time string
+ */
+function formatTimestamp(ms: number): string {
+  if (ms < 0) {
+    return '00:00';
+  }
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const pad = (n: number): string => n.toString().padStart(2, '0');
+
+  if (hours > 0) {
+    return `${hours}:${pad(minutes)}:${pad(seconds)}`;
+  }
+
+  return `${pad(minutes)}:${pad(seconds)}`;
+}
+
+/**
+ * Convert Minutes to Markdown format
+ *
+ * @param minutes - The Minutes object to convert
+ * @returns Markdown string representation
+ *
+ * @example
+ * ```typescript
+ * const markdown = minutesToMarkdown(minutes);
+ * // Returns formatted markdown with all sections
+ * ```
+ */
+export function minutesToMarkdown(minutes: Minutes): string {
+  const lines: string[] = [];
+
+  // Header
+  lines.push(`# ${minutes.title}`);
+  lines.push('');
+  lines.push(`**Date:** ${minutes.date}`);
+  lines.push(`**Duration:** ${formatDuration(minutes.duration)}`);
+  lines.push('');
+
+  // Attendees
+  if (minutes.attendees.length > 0) {
+    lines.push('## Attendees');
+    lines.push('');
+    for (const attendee of minutes.attendees) {
+      lines.push(`- ${attendee.name}`);
+    }
+    lines.push('');
+  }
+
+  // Summary
+  if (minutes.summary) {
+    lines.push('## Summary');
+    lines.push('');
+    lines.push(minutes.summary);
+    lines.push('');
+  }
+
+  // Topics
+  if (minutes.topics.length > 0) {
+    lines.push('## Topics Discussed');
+    lines.push('');
+    for (const topic of minutes.topics) {
+      lines.push(`### ${topic.title}`);
+      lines.push('');
+      lines.push(`*${formatTimestamp(topic.startTime)} - ${formatTimestamp(topic.endTime)}*`);
+      lines.push('');
+      if (topic.summary) {
+        lines.push(topic.summary);
+        lines.push('');
+      }
+      if (topic.keyPoints.length > 0) {
+        lines.push('**Key Points:**');
+        for (const point of topic.keyPoints) {
+          lines.push(`- ${point}`);
+        }
+        lines.push('');
+      }
+      if (topic.speakers.length > 0) {
+        lines.push(`**Speakers:** ${topic.speakers.map((s) => s.name).join(', ')}`);
+        lines.push('');
+      }
+    }
+  }
+
+  // Decisions
+  if (minutes.decisions.length > 0) {
+    lines.push('## Decisions');
+    lines.push('');
+    for (const decision of minutes.decisions) {
+      lines.push(`### ${decision.content}`);
+      lines.push('');
+      if (decision.context) {
+        lines.push(`*Context:* ${decision.context}`);
+        lines.push('');
+      }
+      lines.push(`*Decided at:* ${formatTimestamp(decision.decidedAt)}`);
+      lines.push('');
+    }
+  }
+
+  // Action Items
+  if (minutes.actionItems.length > 0) {
+    lines.push('## Action Items');
+    lines.push('');
+    lines.push('| Task | Assignee | Priority | Due Date | Status |');
+    lines.push('|------|----------|----------|----------|--------|');
+    for (const item of minutes.actionItems) {
+      const assignee = item.assignee?.name ?? 'Unassigned';
+      const dueDate = item.dueDate ?? '-';
+      const status = item.status.replace('_', ' ');
+      lines.push(`| ${item.content} | ${assignee} | ${item.priority} | ${dueDate} | ${status} |`);
+    }
+    lines.push('');
+  }
+
+  // Metadata footer
+  lines.push('---');
+  lines.push('');
+  lines.push(`*Generated: ${minutes.metadata.generatedAt} | Model: ${minutes.metadata.model} | Confidence: ${(minutes.metadata.confidence * 100).toFixed(1)}%*`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Filter action items by status
+ *
+ * @param items - Array of action items to filter
+ * @param status - Status to filter by
+ * @returns Filtered array of action items
+ *
+ * @example
+ * ```typescript
+ * const pendingItems = filterActionItemsByStatus(items, 'pending');
+ * const completedItems = filterActionItemsByStatus(items, 'completed');
+ * ```
+ */
+export function filterActionItemsByStatus(
+  items: readonly ActionItem[],
+  status: ActionItemStatus
+): ActionItem[] {
+  return items.filter((item) => item.status === status);
+}
+
+/**
+ * Priority order mapping for sorting
+ */
+const PRIORITY_ORDER: Record<Priority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+/**
+ * Sort action items by priority (high -> medium -> low)
+ *
+ * @param items - Array of action items to sort
+ * @returns New sorted array of action items
+ *
+ * @example
+ * ```typescript
+ * const sorted = sortActionItemsByPriority(items);
+ * // sorted[0].priority === 'high'
+ * ```
+ */
+export function sortActionItemsByPriority(items: readonly ActionItem[]): ActionItem[] {
+  return [...items].sort((a, b) => PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]);
+}
+
+/**
+ * Get action items assigned to a specific speaker
+ *
+ * @param items - Array of action items
+ * @param speakerId - Speaker ID to filter by
+ * @returns Array of action items assigned to the speaker
+ */
+export function getActionItemsByAssignee(
+  items: readonly ActionItem[],
+  speakerId: string
+): ActionItem[] {
+  return items.filter((item) => item.assignee?.id === speakerId);
+}
+
+/**
+ * Get total duration of all topic segments
+ *
+ * @param topics - Array of topic segments
+ * @returns Total duration in milliseconds
+ */
+export function getTotalTopicsDuration(topics: readonly TopicSegment[]): number {
+  return topics.reduce((total, topic) => total + (topic.endTime - topic.startTime), 0);
+}
+
+/**
+ * Find topic segment by ID
+ *
+ * @param minutes - Minutes object to search
+ * @param topicId - Topic ID to find
+ * @returns TopicSegment if found, undefined otherwise
+ */
+export function findTopicById(
+  minutes: Minutes,
+  topicId: string
+): TopicSegment | undefined {
+  return minutes.topics.find((topic) => topic.id === topicId);
+}
+
+/**
+ * Get decisions related to a specific topic
+ *
+ * @param minutes - Minutes object
+ * @param topicId - Topic ID to filter by
+ * @returns Array of decision items related to the topic
+ */
+export function getDecisionsByTopicId(
+  minutes: Minutes,
+  topicId: string
+): DecisionItem[] {
+  return minutes.decisions.filter((decision) => decision.relatedTopicId === topicId);
+}
+
+/**
+ * Get action items related to a specific topic
+ *
+ * @param minutes - Minutes object
+ * @param topicId - Topic ID to filter by
+ * @returns Array of action items related to the topic
+ */
+export function getActionItemsByTopicId(
+  minutes: Minutes,
+  topicId: string
+): ActionItem[] {
+  return minutes.actionItems.filter((item) => item.relatedTopicId === topicId);
+}
+
+/**
+ * Calculate completion percentage of action items
+ *
+ * @param items - Array of action items
+ * @returns Completion percentage (0-100)
+ */
+export function calculateCompletionPercentage(items: readonly ActionItem[]): number {
+  if (items.length === 0) {
+    return 0;
+  }
+  const completed = items.filter((item) => item.status === 'completed').length;
+  return Math.round((completed / items.length) * 100);
+}
+
+/**
+ * Create a new Speaker object
+ *
+ * @param id - Speaker ID
+ * @param name - Speaker name
+ * @param larkUserId - Optional Lark user ID
+ * @returns Speaker object
+ */
+export function createSpeaker(
+  id: string,
+  name: string,
+  larkUserId?: string
+): Speaker {
+  const speaker: Speaker = {
+    id,
+    name,
+  };
+
+  if (larkUserId !== undefined) {
+    return { ...speaker, larkUserId };
+  }
+
+  return speaker;
+}
+
+/**
+ * Create a new ActionItem object
+ *
+ * @param content - Task content
+ * @param priority - Priority level (default: 'medium')
+ * @param assignee - Optional assignee
+ * @param dueDate - Optional due date
+ * @returns ActionItem object
+ */
+export function createActionItem(
+  content: string,
+  priority: Priority = 'medium',
+  assignee?: Speaker,
+  dueDate?: string
+): ActionItem {
+  const base: ActionItem = {
+    id: generateId('action'),
+    content,
+    priority,
+    status: 'pending',
+  };
+
+  if (assignee !== undefined && dueDate !== undefined) {
+    return { ...base, assignee, dueDate };
+  } else if (assignee !== undefined) {
+    return { ...base, assignee };
+  } else if (dueDate !== undefined) {
+    return { ...base, dueDate };
+  }
+
+  return base;
+}
+
+/**
+ * Create a new DecisionItem object
+ *
+ * @param content - Decision content
+ * @param context - Context or reasoning
+ * @param decidedAt - Time of decision in milliseconds
+ * @param relatedTopicId - Optional related topic ID
+ * @returns DecisionItem object
+ */
+export function createDecisionItem(
+  content: string,
+  context: string,
+  decidedAt: number,
+  relatedTopicId?: string
+): DecisionItem {
+  const base: DecisionItem = {
+    id: generateId('decision'),
+    content,
+    context,
+    decidedAt,
+  };
+
+  if (relatedTopicId !== undefined) {
+    return { ...base, relatedTopicId };
+  }
+
+  return base;
+}
+
+/**
+ * Create a new TopicSegment object
+ *
+ * @param title - Topic title
+ * @param startTime - Start time in milliseconds
+ * @param endTime - End time in milliseconds
+ * @param summary - Topic summary
+ * @param keyPoints - Key points array
+ * @param speakers - Speakers array
+ * @returns TopicSegment object
+ */
+export function createTopicSegment(
+  title: string,
+  startTime: number,
+  endTime: number,
+  summary: string = '',
+  keyPoints: string[] = [],
+  speakers: Speaker[] = []
+): TopicSegment {
+  return {
+    id: generateId('topic'),
+    title,
+    startTime,
+    endTime,
+    summary,
+    keyPoints,
+    speakers,
+  };
+}
+
+// ============================================================================
+// Validation Functions
+// ============================================================================
+
+/**
+ * Validate a Minutes object using Zod schema
+ *
+ * @param data - Data to validate
+ * @returns Validation result with success flag and data/error
+ */
+export function validateMinutes(data: unknown): z.SafeParseReturnType<unknown, Minutes> {
+  return MinutesSchema.safeParse(data);
+}
+
+/**
+ * Validate an ActionItem object using Zod schema
+ *
+ * @param data - Data to validate
+ * @returns Validation result with success flag and data/error
+ */
+export function validateActionItem(data: unknown): z.SafeParseReturnType<unknown, ActionItem> {
+  return ActionItemSchema.safeParse(data);
+}
+
+/**
+ * Validate a TopicSegment object using Zod schema
+ *
+ * @param data - Data to validate
+ * @returns Validation result with success flag and data/error
+ */
+export function validateTopicSegment(data: unknown): z.SafeParseReturnType<unknown, TopicSegment> {
+  return TopicSegmentSchema.safeParse(data);
+}
+
+/**
+ * Validate a Speaker object using Zod schema
+ *
+ * @param data - Data to validate
+ * @returns Validation result with success flag and data/error
+ */
+export function validateSpeaker(data: unknown): z.SafeParseReturnType<unknown, Speaker> {
+  return SpeakerSchema.safeParse(data);
+}
+
+/**
+ * Validate a DecisionItem object using Zod schema
+ *
+ * @param data - Data to validate
+ * @returns Validation result with success flag and data/error
+ */
+export function validateDecisionItem(data: unknown): z.SafeParseReturnType<unknown, DecisionItem> {
+  return DecisionItemSchema.safeParse(data);
+}

--- a/tests/types/minutes.test.ts
+++ b/tests/types/minutes.test.ts
@@ -1,0 +1,1121 @@
+/**
+ * Unit tests for minutes type definitions, Zod schemas, and utility functions
+ * @module tests/types/minutes
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  // Schemas
+  SpeakerSchema,
+  TopicSegmentSchema,
+  DecisionItemSchema,
+  ActionItemSchema,
+  MinutesMetadataSchema,
+  MinutesSchema,
+  PrioritySchema,
+  ActionItemStatusSchema,
+  // Types
+  type Speaker,
+  type TopicSegment,
+  type DecisionItem,
+  type ActionItem,
+  type Minutes,
+  type MinutesMetadata,
+  type Priority,
+  type ActionItemStatus,
+  // Utility functions
+  generateId,
+  createEmptyMinutes,
+  minutesToMarkdown,
+  filterActionItemsByStatus,
+  sortActionItemsByPriority,
+  getActionItemsByAssignee,
+  getTotalTopicsDuration,
+  findTopicById,
+  getDecisionsByTopicId,
+  getActionItemsByTopicId,
+  calculateCompletionPercentage,
+  createSpeaker,
+  createActionItem,
+  createDecisionItem,
+  createTopicSegment,
+  // Validation functions
+  validateMinutes,
+  validateActionItem,
+  validateTopicSegment,
+  validateSpeaker,
+  validateDecisionItem,
+} from '@/types/minutes';
+
+// ============================================================================
+// Test Data Fixtures
+// ============================================================================
+
+const createTestSpeaker = (id: string, name: string, larkUserId?: string): Speaker => {
+  const speaker: Speaker = { id, name };
+  if (larkUserId !== undefined) {
+    return { ...speaker, larkUserId };
+  }
+  return speaker;
+};
+
+const speaker1 = createTestSpeaker('speaker-1', 'Alice');
+const speaker2 = createTestSpeaker('speaker-2', 'Bob');
+const speaker3 = createTestSpeaker('speaker-3', 'Charlie', 'lark-user-123');
+
+const createTestTopic = (
+  id: string,
+  title: string,
+  startTime: number,
+  endTime: number,
+  speakers: Speaker[] = []
+): TopicSegment => ({
+  id,
+  title,
+  startTime,
+  endTime,
+  summary: `Summary of ${title}`,
+  keyPoints: ['Point 1', 'Point 2'],
+  speakers,
+});
+
+const createTestDecision = (
+  id: string,
+  content: string,
+  decidedAt: number,
+  relatedTopicId?: string
+): DecisionItem => {
+  const decision: DecisionItem = {
+    id,
+    content,
+    context: 'Background context',
+    decidedAt,
+  };
+  if (relatedTopicId !== undefined) {
+    return { ...decision, relatedTopicId };
+  }
+  return decision;
+};
+
+const createTestActionItem = (
+  id: string,
+  content: string,
+  priority: Priority,
+  status: ActionItemStatus,
+  assignee?: Speaker,
+  relatedTopicId?: string,
+  dueDate?: string
+): ActionItem => {
+  const item: ActionItem = {
+    id,
+    content,
+    priority,
+    status,
+  };
+
+  const result: ActionItem = {
+    ...item,
+    ...(assignee !== undefined ? { assignee } : {}),
+    ...(relatedTopicId !== undefined ? { relatedTopicId } : {}),
+    ...(dueDate !== undefined ? { dueDate } : {}),
+  };
+
+  return result;
+};
+
+const createTestMinutes = (): Minutes => ({
+  id: 'min-123',
+  meetingId: 'meeting-456',
+  title: 'Weekly Standup',
+  date: '2024-01-15',
+  duration: 3600000, // 1 hour
+  summary: 'Discussed project progress and upcoming tasks.',
+  topics: [
+    createTestTopic('topic-1', 'Project Status', 0, 1200000, [speaker1, speaker2]),
+    createTestTopic('topic-2', 'Technical Issues', 1200000, 2400000, [speaker2, speaker3]),
+  ],
+  decisions: [
+    createTestDecision('decision-1', 'Use TypeScript for new modules', 600000, 'topic-1'),
+    createTestDecision('decision-2', 'Schedule code review weekly', 1800000),
+  ],
+  actionItems: [
+    createTestActionItem('action-1', 'Update documentation', 'high', 'pending', speaker1, 'topic-1', '2024-01-20'),
+    createTestActionItem('action-2', 'Fix bug in auth module', 'medium', 'in_progress', speaker2),
+    createTestActionItem('action-3', 'Review PR #123', 'low', 'completed', speaker3, 'topic-2'),
+  ],
+  attendees: [speaker1, speaker2, speaker3],
+  metadata: {
+    generatedAt: '2024-01-15T10:00:00Z',
+    model: 'claude-sonnet-4-20250514',
+    processingTimeMs: 2500,
+    confidence: 0.92,
+  },
+});
+
+// ============================================================================
+// Zod Schema Tests - Speaker
+// ============================================================================
+
+describe('SpeakerSchema', () => {
+  it('should validate a valid speaker without larkUserId', () => {
+    const result = SpeakerSchema.safeParse({ id: 'user-1', name: 'John' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ id: 'user-1', name: 'John' });
+    }
+  });
+
+  it('should validate a valid speaker with larkUserId', () => {
+    const result = SpeakerSchema.safeParse({
+      id: 'user-1',
+      name: 'John',
+      larkUserId: 'lark-123',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.larkUserId).toBe('lark-123');
+    }
+  });
+
+  it('should reject speaker with empty id', () => {
+    const result = SpeakerSchema.safeParse({ id: '', name: 'John' });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject speaker with empty name', () => {
+    const result = SpeakerSchema.safeParse({ id: 'user-1', name: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject speaker without required fields', () => {
+    const result = SpeakerSchema.safeParse({ id: 'user-1' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// Zod Schema Tests - TopicSegment
+// ============================================================================
+
+describe('TopicSegmentSchema', () => {
+  it('should validate a valid topic segment', () => {
+    const topic = {
+      id: 'topic-1',
+      title: 'Introduction',
+      startTime: 0,
+      endTime: 60000,
+      summary: 'Opening remarks',
+      keyPoints: ['Welcome', 'Agenda overview'],
+      speakers: [{ id: 'user-1', name: 'Host' }],
+    };
+    const result = TopicSegmentSchema.safeParse(topic);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject topic where endTime is less than startTime', () => {
+    const topic = {
+      id: 'topic-1',
+      title: 'Introduction',
+      startTime: 60000,
+      endTime: 30000, // Invalid: less than startTime
+      summary: 'Opening remarks',
+      keyPoints: [],
+      speakers: [],
+    };
+    const result = TopicSegmentSchema.safeParse(topic);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toContain('endTime');
+    }
+  });
+
+  it('should accept topic where endTime equals startTime', () => {
+    const topic = {
+      id: 'topic-1',
+      title: 'Quick Note',
+      startTime: 60000,
+      endTime: 60000,
+      summary: '',
+      keyPoints: [],
+      speakers: [],
+    };
+    const result = TopicSegmentSchema.safeParse(topic);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject negative startTime', () => {
+    const topic = {
+      id: 'topic-1',
+      title: 'Introduction',
+      startTime: -1000,
+      endTime: 60000,
+      summary: '',
+      keyPoints: [],
+      speakers: [],
+    };
+    const result = TopicSegmentSchema.safeParse(topic);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// Zod Schema Tests - DecisionItem
+// ============================================================================
+
+describe('DecisionItemSchema', () => {
+  it('should validate a valid decision item', () => {
+    const decision = {
+      id: 'decision-1',
+      content: 'Approved new feature',
+      context: 'Based on user feedback',
+      decidedAt: 120000,
+    };
+    const result = DecisionItemSchema.safeParse(decision);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate decision with relatedTopicId', () => {
+    const decision = {
+      id: 'decision-1',
+      content: 'Approved new feature',
+      context: 'Based on user feedback',
+      decidedAt: 120000,
+      relatedTopicId: 'topic-1',
+    };
+    const result = DecisionItemSchema.safeParse(decision);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.relatedTopicId).toBe('topic-1');
+    }
+  });
+
+  it('should reject decision with empty content', () => {
+    const decision = {
+      id: 'decision-1',
+      content: '',
+      context: 'Background',
+      decidedAt: 120000,
+    };
+    const result = DecisionItemSchema.safeParse(decision);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// Zod Schema Tests - ActionItem
+// ============================================================================
+
+describe('ActionItemSchema', () => {
+  it('should validate a valid action item', () => {
+    const action = {
+      id: 'action-1',
+      content: 'Complete task',
+      priority: 'high',
+      status: 'pending',
+    };
+    const result = ActionItemSchema.safeParse(action);
+    expect(result.success).toBe(true);
+  });
+
+  it('should validate action item with all optional fields', () => {
+    const action = {
+      id: 'action-1',
+      content: 'Complete task',
+      assignee: { id: 'user-1', name: 'Alice' },
+      dueDate: '2024-01-20',
+      priority: 'medium',
+      status: 'in_progress',
+      relatedTopicId: 'topic-1',
+    };
+    const result = ActionItemSchema.safeParse(action);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid priority', () => {
+    const action = {
+      id: 'action-1',
+      content: 'Complete task',
+      priority: 'urgent', // Invalid
+      status: 'pending',
+    };
+    const result = ActionItemSchema.safeParse(action);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid status', () => {
+    const action = {
+      id: 'action-1',
+      content: 'Complete task',
+      priority: 'high',
+      status: 'cancelled', // Invalid - not in the enum
+    };
+    const result = ActionItemSchema.safeParse(action);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject invalid dueDate format', () => {
+    const action = {
+      id: 'action-1',
+      content: 'Complete task',
+      priority: 'high',
+      status: 'pending',
+      dueDate: '01-20-2024', // Invalid format
+    };
+    const result = ActionItemSchema.safeParse(action);
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept valid ISO date format for dueDate', () => {
+    const action = {
+      id: 'action-1',
+      content: 'Complete task',
+      priority: 'high',
+      status: 'pending',
+      dueDate: '2024-01-20',
+    };
+    const result = ActionItemSchema.safeParse(action);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Zod Schema Tests - MinutesMetadata
+// ============================================================================
+
+describe('MinutesMetadataSchema', () => {
+  it('should validate valid metadata', () => {
+    const metadata = {
+      generatedAt: '2024-01-15T10:00:00Z',
+      model: 'claude-sonnet-4-20250514',
+      processingTimeMs: 2500,
+      confidence: 0.92,
+    };
+    const result = MinutesMetadataSchema.safeParse(metadata);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject confidence greater than 1', () => {
+    const metadata = {
+      generatedAt: '2024-01-15T10:00:00Z',
+      model: 'claude-sonnet-4-20250514',
+      processingTimeMs: 2500,
+      confidence: 1.5, // Invalid
+    };
+    const result = MinutesMetadataSchema.safeParse(metadata);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject negative confidence', () => {
+    const metadata = {
+      generatedAt: '2024-01-15T10:00:00Z',
+      model: 'claude-sonnet-4-20250514',
+      processingTimeMs: 2500,
+      confidence: -0.1, // Invalid
+    };
+    const result = MinutesMetadataSchema.safeParse(metadata);
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept confidence at boundaries (0 and 1)', () => {
+    const metadata0 = {
+      generatedAt: '2024-01-15T10:00:00Z',
+      model: 'test',
+      processingTimeMs: 0,
+      confidence: 0,
+    };
+    const metadata1 = {
+      generatedAt: '2024-01-15T10:00:00Z',
+      model: 'test',
+      processingTimeMs: 0,
+      confidence: 1,
+    };
+    expect(MinutesMetadataSchema.safeParse(metadata0).success).toBe(true);
+    expect(MinutesMetadataSchema.safeParse(metadata1).success).toBe(true);
+  });
+});
+
+// ============================================================================
+// Zod Schema Tests - Minutes
+// ============================================================================
+
+describe('MinutesSchema', () => {
+  it('should validate a complete minutes object', () => {
+    const minutes = createTestMinutes();
+    const result = MinutesSchema.safeParse(minutes);
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject invalid date format', () => {
+    const minutes = createTestMinutes();
+    const invalidMinutes = { ...minutes, date: '15-01-2024' };
+    const result = MinutesSchema.safeParse(invalidMinutes);
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject minutes with empty arrays', () => {
+    const minutes = createTestMinutes();
+    const minimalMinutes = {
+      ...minutes,
+      topics: [],
+      decisions: [],
+      actionItems: [],
+      attendees: [],
+    };
+    const result = MinutesSchema.safeParse(minimalMinutes);
+    expect(result.success).toBe(true); // Empty arrays are valid
+  });
+});
+
+// ============================================================================
+// Priority and Status Schema Tests
+// ============================================================================
+
+describe('PrioritySchema', () => {
+  it('should accept valid priorities', () => {
+    expect(PrioritySchema.safeParse('high').success).toBe(true);
+    expect(PrioritySchema.safeParse('medium').success).toBe(true);
+    expect(PrioritySchema.safeParse('low').success).toBe(true);
+  });
+
+  it('should reject invalid priorities', () => {
+    expect(PrioritySchema.safeParse('urgent').success).toBe(false);
+    expect(PrioritySchema.safeParse('critical').success).toBe(false);
+    expect(PrioritySchema.safeParse('').success).toBe(false);
+  });
+});
+
+describe('ActionItemStatusSchema', () => {
+  it('should accept valid statuses', () => {
+    expect(ActionItemStatusSchema.safeParse('pending').success).toBe(true);
+    expect(ActionItemStatusSchema.safeParse('in_progress').success).toBe(true);
+    expect(ActionItemStatusSchema.safeParse('completed').success).toBe(true);
+  });
+
+  it('should reject invalid statuses', () => {
+    expect(ActionItemStatusSchema.safeParse('cancelled').success).toBe(false);
+    expect(ActionItemStatusSchema.safeParse('done').success).toBe(false);
+    expect(ActionItemStatusSchema.safeParse('').success).toBe(false);
+  });
+});
+
+// ============================================================================
+// generateId Tests
+// ============================================================================
+
+describe('generateId', () => {
+  it('should generate ID with correct prefix', () => {
+    const id = generateId('test');
+    expect(id.startsWith('test_')).toBe(true);
+  });
+
+  it('should generate unique IDs', () => {
+    const id1 = generateId('item');
+    const id2 = generateId('item');
+    expect(id1).not.toBe(id2);
+  });
+
+  it('should generate IDs with expected format', () => {
+    const id = generateId('prefix');
+    // Format: prefix_timestamp_random
+    const parts = id.split('_');
+    expect(parts.length).toBe(3);
+    expect(parts[0]).toBe('prefix');
+  });
+});
+
+// ============================================================================
+// createEmptyMinutes Tests
+// ============================================================================
+
+describe('createEmptyMinutes', () => {
+  it('should create minutes with provided meetingId', () => {
+    const minutes = createEmptyMinutes('meeting-123');
+    expect(minutes.meetingId).toBe('meeting-123');
+  });
+
+  it('should create minutes with provided title', () => {
+    const minutes = createEmptyMinutes('meeting-123', 'Team Sync');
+    expect(minutes.title).toBe('Team Sync');
+  });
+
+  it('should use default title when not provided', () => {
+    const minutes = createEmptyMinutes('meeting-123');
+    expect(minutes.title).toBe('Untitled Meeting');
+  });
+
+  it('should have empty arrays for collections', () => {
+    const minutes = createEmptyMinutes('meeting-123');
+    expect(minutes.topics).toEqual([]);
+    expect(minutes.decisions).toEqual([]);
+    expect(minutes.actionItems).toEqual([]);
+    expect(minutes.attendees).toEqual([]);
+  });
+
+  it('should have valid metadata', () => {
+    const minutes = createEmptyMinutes('meeting-123');
+    expect(minutes.metadata.model).toBe('unknown');
+    expect(minutes.metadata.processingTimeMs).toBe(0);
+    expect(minutes.metadata.confidence).toBe(0);
+    expect(minutes.metadata.generatedAt).toBeDefined();
+  });
+
+  it('should generate unique ID', () => {
+    const minutes1 = createEmptyMinutes('meeting-1');
+    const minutes2 = createEmptyMinutes('meeting-2');
+    expect(minutes1.id).not.toBe(minutes2.id);
+  });
+
+  it('should set date to current date', () => {
+    const minutes = createEmptyMinutes('meeting-123');
+    const today = new Date().toISOString().split('T')[0];
+    expect(minutes.date).toBe(today);
+  });
+});
+
+// ============================================================================
+// minutesToMarkdown Tests
+// ============================================================================
+
+describe('minutesToMarkdown', () => {
+  let testMinutes: Minutes;
+
+  beforeEach(() => {
+    testMinutes = createTestMinutes();
+  });
+
+  it('should include title as H1 header', () => {
+    const markdown = minutesToMarkdown(testMinutes);
+    expect(markdown).toContain('# Weekly Standup');
+  });
+
+  it('should include date and duration', () => {
+    const markdown = minutesToMarkdown(testMinutes);
+    expect(markdown).toContain('**Date:** 2024-01-15');
+    expect(markdown).toContain('**Duration:** 1h');
+  });
+
+  it('should include attendees section', () => {
+    const markdown = minutesToMarkdown(testMinutes);
+    expect(markdown).toContain('## Attendees');
+    expect(markdown).toContain('- Alice');
+    expect(markdown).toContain('- Bob');
+    expect(markdown).toContain('- Charlie');
+  });
+
+  it('should include summary section', () => {
+    const markdown = minutesToMarkdown(testMinutes);
+    expect(markdown).toContain('## Summary');
+    expect(markdown).toContain('Discussed project progress and upcoming tasks.');
+  });
+
+  it('should include topics section', () => {
+    const markdown = minutesToMarkdown(testMinutes);
+    expect(markdown).toContain('## Topics Discussed');
+    expect(markdown).toContain('### Project Status');
+    expect(markdown).toContain('### Technical Issues');
+  });
+
+  it('should include topic time ranges', () => {
+    const markdown = minutesToMarkdown(testMinutes);
+    expect(markdown).toContain('*00:00 - 20:00*'); // 0ms - 1200000ms
+    expect(markdown).toContain('*20:00 - 40:00*'); // 1200000ms - 2400000ms
+  });
+
+  it('should include decisions section', () => {
+    const markdown = minutesToMarkdown(testMinutes);
+    expect(markdown).toContain('## Decisions');
+    expect(markdown).toContain('### Use TypeScript for new modules');
+    expect(markdown).toContain('### Schedule code review weekly');
+  });
+
+  it('should include action items table', () => {
+    const markdown = minutesToMarkdown(testMinutes);
+    expect(markdown).toContain('## Action Items');
+    expect(markdown).toContain('| Task | Assignee | Priority | Due Date | Status |');
+    expect(markdown).toContain('| Update documentation | Alice | high | 2024-01-20 | pending |');
+  });
+
+  it('should include metadata footer', () => {
+    const markdown = minutesToMarkdown(testMinutes);
+    expect(markdown).toContain('*Generated: 2024-01-15T10:00:00Z');
+    expect(markdown).toContain('Model: claude-sonnet-4-20250514');
+    expect(markdown).toContain('Confidence: 92.0%');
+  });
+
+  it('should handle empty minutes gracefully', () => {
+    const emptyMinutes = createEmptyMinutes('meeting-123', 'Empty Meeting');
+    const markdown = minutesToMarkdown(emptyMinutes);
+    expect(markdown).toContain('# Empty Meeting');
+    expect(markdown).not.toContain('## Attendees');
+    expect(markdown).not.toContain('## Topics Discussed');
+    expect(markdown).not.toContain('## Decisions');
+    expect(markdown).not.toContain('## Action Items');
+  });
+
+  it('should format duration correctly for various lengths', () => {
+    const shortMeeting = { ...testMinutes, duration: 1800000 }; // 30 minutes
+    expect(minutesToMarkdown(shortMeeting)).toContain('**Duration:** 30m');
+
+    const longMeeting = { ...testMinutes, duration: 5400000 }; // 1.5 hours
+    expect(minutesToMarkdown(longMeeting)).toContain('**Duration:** 1h 30m');
+
+    const exactHour = { ...testMinutes, duration: 7200000 }; // 2 hours
+    expect(minutesToMarkdown(exactHour)).toContain('**Duration:** 2h');
+  });
+});
+
+// ============================================================================
+// filterActionItemsByStatus Tests
+// ============================================================================
+
+describe('filterActionItemsByStatus', () => {
+  const testItems: ActionItem[] = [
+    createTestActionItem('action-1', 'Task 1', 'high', 'pending'),
+    createTestActionItem('action-2', 'Task 2', 'medium', 'in_progress'),
+    createTestActionItem('action-3', 'Task 3', 'low', 'completed'),
+    createTestActionItem('action-4', 'Task 4', 'high', 'pending'),
+  ];
+
+  it('should filter pending items', () => {
+    const result = filterActionItemsByStatus(testItems, 'pending');
+    expect(result).toHaveLength(2);
+    expect(result.every((item) => item.status === 'pending')).toBe(true);
+  });
+
+  it('should filter in_progress items', () => {
+    const result = filterActionItemsByStatus(testItems, 'in_progress');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.status).toBe('in_progress');
+  });
+
+  it('should filter completed items', () => {
+    const result = filterActionItemsByStatus(testItems, 'completed');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.status).toBe('completed');
+  });
+
+  it('should return empty array when no items match', () => {
+    const pendingOnly = testItems.filter((item) => item.status === 'pending');
+    const result = filterActionItemsByStatus(pendingOnly, 'completed');
+    expect(result).toHaveLength(0);
+  });
+
+  it('should work with empty array', () => {
+    const result = filterActionItemsByStatus([], 'pending');
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// sortActionItemsByPriority Tests
+// ============================================================================
+
+describe('sortActionItemsByPriority', () => {
+  it('should sort items by priority (high first)', () => {
+    const items: ActionItem[] = [
+      createTestActionItem('action-1', 'Low task', 'low', 'pending'),
+      createTestActionItem('action-2', 'High task', 'high', 'pending'),
+      createTestActionItem('action-3', 'Medium task', 'medium', 'pending'),
+    ];
+
+    const sorted = sortActionItemsByPriority(items);
+    expect(sorted[0]?.priority).toBe('high');
+    expect(sorted[1]?.priority).toBe('medium');
+    expect(sorted[2]?.priority).toBe('low');
+  });
+
+  it('should not mutate original array', () => {
+    const items: ActionItem[] = [
+      createTestActionItem('action-1', 'Low task', 'low', 'pending'),
+      createTestActionItem('action-2', 'High task', 'high', 'pending'),
+    ];
+    const originalFirst = items[0];
+
+    sortActionItemsByPriority(items);
+    expect(items[0]).toBe(originalFirst);
+  });
+
+  it('should handle items with same priority', () => {
+    const items: ActionItem[] = [
+      createTestActionItem('action-1', 'First high', 'high', 'pending'),
+      createTestActionItem('action-2', 'Second high', 'high', 'pending'),
+    ];
+
+    const sorted = sortActionItemsByPriority(items);
+    expect(sorted).toHaveLength(2);
+    expect(sorted.every((item) => item.priority === 'high')).toBe(true);
+  });
+
+  it('should handle empty array', () => {
+    const sorted = sortActionItemsByPriority([]);
+    expect(sorted).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// getActionItemsByAssignee Tests
+// ============================================================================
+
+describe('getActionItemsByAssignee', () => {
+  const testItems: ActionItem[] = [
+    createTestActionItem('action-1', 'Task 1', 'high', 'pending', speaker1),
+    createTestActionItem('action-2', 'Task 2', 'medium', 'pending', speaker2),
+    createTestActionItem('action-3', 'Task 3', 'low', 'pending', speaker1),
+    createTestActionItem('action-4', 'Task 4', 'high', 'pending'), // No assignee
+  ];
+
+  it('should return items assigned to specific speaker', () => {
+    const result = getActionItemsByAssignee(testItems, 'speaker-1');
+    expect(result).toHaveLength(2);
+    expect(result.every((item) => item.assignee?.id === 'speaker-1')).toBe(true);
+  });
+
+  it('should return empty array for speaker with no assignments', () => {
+    const result = getActionItemsByAssignee(testItems, 'speaker-999');
+    expect(result).toHaveLength(0);
+  });
+
+  it('should not include items without assignee', () => {
+    const result = getActionItemsByAssignee(testItems, 'speaker-1');
+    expect(result.every((item) => item.assignee !== undefined)).toBe(true);
+  });
+});
+
+// ============================================================================
+// getTotalTopicsDuration Tests
+// ============================================================================
+
+describe('getTotalTopicsDuration', () => {
+  it('should calculate total duration of topics', () => {
+    const topics: TopicSegment[] = [
+      createTestTopic('topic-1', 'Topic 1', 0, 60000),
+      createTestTopic('topic-2', 'Topic 2', 60000, 180000),
+    ];
+
+    const total = getTotalTopicsDuration(topics);
+    expect(total).toBe(180000); // 60000 + 120000
+  });
+
+  it('should return 0 for empty array', () => {
+    const total = getTotalTopicsDuration([]);
+    expect(total).toBe(0);
+  });
+
+  it('should handle overlapping topics correctly (sums individual durations)', () => {
+    const topics: TopicSegment[] = [
+      createTestTopic('topic-1', 'Topic 1', 0, 120000),
+      createTestTopic('topic-2', 'Topic 2', 60000, 180000), // Overlaps
+    ];
+
+    const total = getTotalTopicsDuration(topics);
+    expect(total).toBe(240000); // 120000 + 120000
+  });
+});
+
+// ============================================================================
+// findTopicById Tests
+// ============================================================================
+
+describe('findTopicById', () => {
+  const testMinutes = createTestMinutes();
+
+  it('should find topic by ID', () => {
+    const topic = findTopicById(testMinutes, 'topic-1');
+    expect(topic).toBeDefined();
+    expect(topic?.title).toBe('Project Status');
+  });
+
+  it('should return undefined for non-existent ID', () => {
+    const topic = findTopicById(testMinutes, 'topic-999');
+    expect(topic).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// getDecisionsByTopicId Tests
+// ============================================================================
+
+describe('getDecisionsByTopicId', () => {
+  const testMinutes = createTestMinutes();
+
+  it('should return decisions related to specific topic', () => {
+    const decisions = getDecisionsByTopicId(testMinutes, 'topic-1');
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]?.content).toBe('Use TypeScript for new modules');
+  });
+
+  it('should return empty array for topic with no decisions', () => {
+    const decisions = getDecisionsByTopicId(testMinutes, 'topic-2');
+    expect(decisions).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// getActionItemsByTopicId Tests
+// ============================================================================
+
+describe('getActionItemsByTopicId', () => {
+  const testMinutes = createTestMinutes();
+
+  it('should return action items related to specific topic', () => {
+    const actions = getActionItemsByTopicId(testMinutes, 'topic-1');
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.content).toBe('Update documentation');
+  });
+
+  it('should return action items for another topic', () => {
+    const actions = getActionItemsByTopicId(testMinutes, 'topic-2');
+    expect(actions).toHaveLength(1);
+    expect(actions[0]?.content).toBe('Review PR #123');
+  });
+});
+
+// ============================================================================
+// calculateCompletionPercentage Tests
+// ============================================================================
+
+describe('calculateCompletionPercentage', () => {
+  it('should calculate 0% for no completed items', () => {
+    const items: ActionItem[] = [
+      createTestActionItem('action-1', 'Task 1', 'high', 'pending'),
+      createTestActionItem('action-2', 'Task 2', 'medium', 'in_progress'),
+    ];
+    expect(calculateCompletionPercentage(items)).toBe(0);
+  });
+
+  it('should calculate 100% when all items completed', () => {
+    const items: ActionItem[] = [
+      createTestActionItem('action-1', 'Task 1', 'high', 'completed'),
+      createTestActionItem('action-2', 'Task 2', 'medium', 'completed'),
+    ];
+    expect(calculateCompletionPercentage(items)).toBe(100);
+  });
+
+  it('should calculate 50% when half items completed', () => {
+    const items: ActionItem[] = [
+      createTestActionItem('action-1', 'Task 1', 'high', 'completed'),
+      createTestActionItem('action-2', 'Task 2', 'medium', 'pending'),
+    ];
+    expect(calculateCompletionPercentage(items)).toBe(50);
+  });
+
+  it('should return 0 for empty array', () => {
+    expect(calculateCompletionPercentage([])).toBe(0);
+  });
+
+  it('should round to nearest integer', () => {
+    const items: ActionItem[] = [
+      createTestActionItem('action-1', 'Task 1', 'high', 'completed'),
+      createTestActionItem('action-2', 'Task 2', 'medium', 'pending'),
+      createTestActionItem('action-3', 'Task 3', 'low', 'pending'),
+    ];
+    expect(calculateCompletionPercentage(items)).toBe(33); // 1/3 = 33.33...%
+  });
+});
+
+// ============================================================================
+// Factory Function Tests - createSpeaker
+// ============================================================================
+
+describe('createSpeaker', () => {
+  it('should create speaker without larkUserId', () => {
+    const speaker = createSpeaker('user-1', 'John');
+    expect(speaker).toEqual({ id: 'user-1', name: 'John' });
+    expect(speaker.larkUserId).toBeUndefined();
+  });
+
+  it('should create speaker with larkUserId', () => {
+    const speaker = createSpeaker('user-1', 'John', 'lark-123');
+    expect(speaker).toEqual({
+      id: 'user-1',
+      name: 'John',
+      larkUserId: 'lark-123',
+    });
+  });
+});
+
+// ============================================================================
+// Factory Function Tests - createActionItem
+// ============================================================================
+
+describe('createActionItem', () => {
+  it('should create action item with default values', () => {
+    const item = createActionItem('Complete task');
+    expect(item.content).toBe('Complete task');
+    expect(item.priority).toBe('medium');
+    expect(item.status).toBe('pending');
+    expect(item.id).toMatch(/^action_/);
+  });
+
+  it('should create action item with custom priority', () => {
+    const item = createActionItem('Urgent task', 'high');
+    expect(item.priority).toBe('high');
+  });
+
+  it('should create action item with assignee', () => {
+    const item = createActionItem('Assigned task', 'medium', speaker1);
+    expect(item.assignee).toEqual(speaker1);
+  });
+
+  it('should create action item with due date', () => {
+    const item = createActionItem('Task with deadline', 'medium', undefined, '2024-01-20');
+    expect(item.dueDate).toBe('2024-01-20');
+  });
+
+  it('should create action item with all options', () => {
+    const item = createActionItem('Full task', 'high', speaker1, '2024-01-20');
+    expect(item.content).toBe('Full task');
+    expect(item.priority).toBe('high');
+    expect(item.assignee).toEqual(speaker1);
+    expect(item.dueDate).toBe('2024-01-20');
+  });
+});
+
+// ============================================================================
+// Factory Function Tests - createDecisionItem
+// ============================================================================
+
+describe('createDecisionItem', () => {
+  it('should create decision item without relatedTopicId', () => {
+    const decision = createDecisionItem('Approved', 'After discussion', 60000);
+    expect(decision.content).toBe('Approved');
+    expect(decision.context).toBe('After discussion');
+    expect(decision.decidedAt).toBe(60000);
+    expect(decision.id).toMatch(/^decision_/);
+    expect(decision.relatedTopicId).toBeUndefined();
+  });
+
+  it('should create decision item with relatedTopicId', () => {
+    const decision = createDecisionItem('Approved', 'Context', 60000, 'topic-1');
+    expect(decision.relatedTopicId).toBe('topic-1');
+  });
+});
+
+// ============================================================================
+// Factory Function Tests - createTopicSegment
+// ============================================================================
+
+describe('createTopicSegment', () => {
+  it('should create topic segment with required fields', () => {
+    const topic = createTopicSegment('Introduction', 0, 60000);
+    expect(topic.title).toBe('Introduction');
+    expect(topic.startTime).toBe(0);
+    expect(topic.endTime).toBe(60000);
+    expect(topic.summary).toBe('');
+    expect(topic.keyPoints).toEqual([]);
+    expect(topic.speakers).toEqual([]);
+    expect(topic.id).toMatch(/^topic_/);
+  });
+
+  it('should create topic segment with all fields', () => {
+    const topic = createTopicSegment(
+      'Discussion',
+      0,
+      60000,
+      'We discussed important matters',
+      ['Point 1', 'Point 2'],
+      [speaker1, speaker2]
+    );
+    expect(topic.summary).toBe('We discussed important matters');
+    expect(topic.keyPoints).toEqual(['Point 1', 'Point 2']);
+    expect(topic.speakers).toEqual([speaker1, speaker2]);
+  });
+});
+
+// ============================================================================
+// Validation Function Tests
+// ============================================================================
+
+describe('validateMinutes', () => {
+  it('should return success for valid minutes', () => {
+    const minutes = createTestMinutes();
+    const result = validateMinutes(minutes);
+    expect(result.success).toBe(true);
+  });
+
+  it('should return error for invalid minutes', () => {
+    const invalid = { id: '', meetingId: 'test' }; // Missing required fields
+    const result = validateMinutes(invalid);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('validateActionItem', () => {
+  it('should return success for valid action item', () => {
+    const item = createActionItem('Task');
+    const result = validateActionItem(item);
+    expect(result.success).toBe(true);
+  });
+
+  it('should return error for invalid action item', () => {
+    const invalid = { id: 'test', content: '' }; // Empty content
+    const result = validateActionItem(invalid);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('validateTopicSegment', () => {
+  it('should return success for valid topic segment', () => {
+    const topic = createTopicSegment('Test', 0, 60000);
+    const result = validateTopicSegment(topic);
+    expect(result.success).toBe(true);
+  });
+
+  it('should return error for invalid topic segment', () => {
+    const invalid = { id: 'test', title: '', startTime: 100, endTime: 50 };
+    const result = validateTopicSegment(invalid);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('validateSpeaker', () => {
+  it('should return success for valid speaker', () => {
+    const speaker = createSpeaker('user-1', 'John');
+    const result = validateSpeaker(speaker);
+    expect(result.success).toBe(true);
+  });
+
+  it('should return error for invalid speaker', () => {
+    const invalid = { id: '', name: 'John' }; // Empty ID
+    const result = validateSpeaker(invalid);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('validateDecisionItem', () => {
+  it('should return success for valid decision item', () => {
+    const decision = createDecisionItem('Decision', 'Context', 60000);
+    const result = validateDecisionItem(decision);
+    expect(result.success).toBe(true);
+  });
+
+  it('should return error for invalid decision item', () => {
+    const invalid = { id: 'test', content: '', context: '', decidedAt: -1 };
+    const result = validateDecisionItem(invalid);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// Type Safety Tests
+// ============================================================================
+
+describe('Type Safety', () => {
+  it('should enforce correct types for Priority', () => {
+    const priority: Priority = 'high';
+    expect(['high', 'medium', 'low']).toContain(priority);
+  });
+
+  it('should enforce correct types for ActionItemStatus', () => {
+    const status: ActionItemStatus = 'pending';
+    expect(['pending', 'in_progress', 'completed']).toContain(status);
+  });
+
+  it('should allow readonly arrays in utility functions', () => {
+    const readonlyItems: readonly ActionItem[] = [
+      createTestActionItem('action-1', 'Task 1', 'high', 'pending'),
+    ];
+    const filtered = filterActionItemsByStatus(readonlyItems, 'pending');
+    expect(filtered).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Claude API統合とAI議事録生成機能を実装
- 文字起こしから構造化議事録を自動生成
- 話題セグメント、決定事項、アクションアイテムを抽出

## 変更内容

### Claude API統合
- `src/lib/claude/client.ts` - ClaudeClient（Anthropic SDK使用）
- `src/lib/claude/types.ts` - 構造化出力サポート（Zodスキーマ検証）
- `src/lib/claude/prompts/` - AIプロンプトテンプレート（日本語会議に最適化）

### 議事録データモデル
- `src/types/minutes.ts` - Minutes, TopicSegment, DecisionItem, ActionItem型
- Zodスキーマによるランタイム検証
- Markdown変換ユーティリティ

### UIコンポーネント
- `src/components/minutes/MinutesViewer.tsx` - メインビューア（タブ切り替え）
- `src/components/minutes/TopicSection.tsx` - 話題セグメント表示
- `src/components/minutes/DecisionList.tsx` - 決定事項リスト
- `src/components/minutes/ActionItemList.tsx` - アクションアイテム（フィルタリング対応）
- `src/components/minutes/GenerateButton.tsx` - 生成ボタン（プログレス表示）

### サービス
- `src/services/minutes-generation.service.ts` - 文字起こし→議事録変換

### API Routes
- `GET /api/meetings/[id]/minutes` - 議事録取得（将来用）
- `POST /api/meetings/[id]/minutes/generate` - 議事録生成

### ページ統合
- `src/app/(dashboard)/meetings/[id]/_components/minutes-section.tsx` - 会議詳細ページへの統合

## 品質スコア
- ReviewAgent: 91/100点でPASS
- TypeScript/ESLint: 0エラー
- テスト: 480件全てパス

## Test plan
- [ ] ClaudeClientテスト
- [ ] プロンプトテスト
- [ ] MinutesGenerationServiceテスト
- [ ] API Routeテスト
- [ ] 会議詳細ページで議事録生成を確認

Closes #6

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>