### PR TITLE
feat(action-items): Add action item extraction and management feature

### DIFF
--- a/src/app/(dashboard)/action-items/_components/action-items-page-client.tsx
+++ b/src/app/(dashboard)/action-items/_components/action-items-page-client.tsx
@@ -1,0 +1,793 @@
+'use client';
+
+/**
+ * Action Items Page Client Component
+ * @module app/(dashboard)/action-items/_components/action-items-page-client
+ */
+
+import { useCallback, useState, useEffect, useMemo, useTransition } from 'react';
+import { useSearchParams, usePathname } from 'next/navigation';
+import {
+  ActionItemStats,
+  ActionItemToolbar,
+  ActionItemList,
+  createDefaultFilters,
+  type ActionItemFilters,
+  type ActionItemSortOptions,
+  type ManagedActionItem,
+  type ActionItemStatus,
+} from '@/components/action-items';
+import { Pagination } from '@/components/ui';
+import type {
+  ActionItemListResponse,
+  ActionItemStatsData,
+} from '@/types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Props for ActionItemsPageClient component
+ */
+export interface ActionItemsPageClientProps {
+  /** Initial action items data from server */
+  readonly initialData: ActionItemListResponse;
+  /** Initial statistics from server */
+  readonly initialStats: ActionItemStatsData;
+}
+
+/**
+ * API response wrapper
+ */
+interface ApiResponse<T> {
+  readonly success: boolean;
+  readonly data?: T;
+  readonly error?: {
+    readonly code: string;
+    readonly message: string;
+  };
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_PAGE_SIZE = 20;
+
+// ============================================================================
+// URL Parameter Utilities
+// ============================================================================
+
+/**
+ * Parse filters from URL search params
+ */
+function parseFiltersFromParams(searchParams: URLSearchParams): ActionItemFilters {
+  const statuses = searchParams.get('status');
+  const priorities = searchParams.get('priority');
+  const assigneeId = searchParams.get('assigneeId');
+  const meetingId = searchParams.get('meetingId');
+  const overdueOnly = searchParams.get('overdue');
+
+  return {
+    statuses: statuses !== null && statuses !== ''
+      ? (statuses.split(',') as ActionItemStatus[])
+      : [],
+    priorities: priorities !== null && priorities !== ''
+      ? (priorities.split(',') as ('high' | 'medium' | 'low')[])
+      : [],
+    assigneeId: assigneeId !== null && assigneeId !== '' ? assigneeId : undefined,
+    meetingId: meetingId !== null && meetingId !== '' ? meetingId : undefined,
+    overdueOnly: overdueOnly === 'true',
+    dueDateRange: undefined,
+  };
+}
+
+/**
+ * Parse sort options from URL search params
+ */
+function parseSortFromParams(searchParams: URLSearchParams): ActionItemSortOptions {
+  const field = searchParams.get('sortField');
+  const direction = searchParams.get('sortOrder');
+
+  const validFields = ['dueDate', 'priority', 'createdAt', 'meetingDate'] as const;
+  const validDirections = ['asc', 'desc'] as const;
+
+  return {
+    field: field !== null && (validFields as readonly string[]).includes(field)
+      ? (field as ActionItemSortOptions['field'])
+      : 'dueDate',
+    direction: direction !== null && (validDirections as readonly string[]).includes(direction)
+      ? (direction as ActionItemSortOptions['direction'])
+      : 'asc',
+  };
+}
+
+/**
+ * Parse pagination from URL search params
+ */
+function parsePaginationFromParams(searchParams: URLSearchParams): { page: number; pageSize: number } {
+  const page = searchParams.get('page');
+  const pageSize = searchParams.get('pageSize');
+
+  const parsedPage = page !== null ? parseInt(page, 10) : 1;
+  const parsedPageSize = pageSize !== null ? parseInt(pageSize, 10) : DEFAULT_PAGE_SIZE;
+
+  return {
+    page: isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage,
+    pageSize: isNaN(parsedPageSize) || parsedPageSize < 1 ? DEFAULT_PAGE_SIZE : Math.min(parsedPageSize, 100),
+  };
+}
+
+/**
+ * Build URL search params from state
+ */
+function buildSearchParams(
+  filters: ActionItemFilters,
+  sort: ActionItemSortOptions,
+  searchQuery: string,
+  page: number,
+  pageSize: number
+): URLSearchParams {
+  const params = new URLSearchParams();
+
+  // Filters
+  if (filters.statuses.length > 0) {
+    params.set('status', filters.statuses.join(','));
+  }
+  if (filters.priorities.length > 0) {
+    params.set('priority', filters.priorities.join(','));
+  }
+  if (filters.assigneeId !== undefined) {
+    params.set('assigneeId', filters.assigneeId);
+  }
+  if (filters.meetingId !== undefined) {
+    params.set('meetingId', filters.meetingId);
+  }
+  if (filters.overdueOnly) {
+    params.set('overdue', 'true');
+  }
+
+  // Search
+  if (searchQuery !== '') {
+    params.set('search', searchQuery);
+  }
+
+  // Sort
+  if (sort.field !== 'dueDate') {
+    params.set('sortField', sort.field);
+  }
+  if (sort.direction !== 'asc') {
+    params.set('sortOrder', sort.direction);
+  }
+
+  // Pagination
+  if (page > 1) {
+    params.set('page', String(page));
+  }
+  if (pageSize !== DEFAULT_PAGE_SIZE) {
+    params.set('pageSize', String(pageSize));
+  }
+
+  return params;
+}
+
+// ============================================================================
+// API Functions
+// ============================================================================
+
+/**
+ * Build API query string from filters
+ */
+function buildApiQueryString(
+  filters: ActionItemFilters,
+  sort: ActionItemSortOptions,
+  searchQuery: string,
+  page: number,
+  pageSize: number
+): string {
+  const params = new URLSearchParams();
+
+  // Filters
+  if (filters.statuses.length > 0) {
+    params.set('status', filters.statuses.join(','));
+  }
+  if (filters.priorities.length > 0) {
+    params.set('priority', filters.priorities.join(','));
+  }
+  if (filters.assigneeId !== undefined) {
+    params.set('assigneeId', filters.assigneeId);
+  }
+  if (filters.meetingId !== undefined) {
+    params.set('meetingId', filters.meetingId);
+  }
+  if (filters.overdueOnly) {
+    params.set('isOverdue', 'true');
+  }
+  if (searchQuery !== '') {
+    params.set('searchQuery', searchQuery);
+  }
+
+  // Sort - convert 'direction' to 'order' for API
+  params.set('sortField', sort.field);
+  params.set('sortOrder', sort.direction);
+
+  // Pagination
+  params.set('page', String(page));
+  params.set('pageSize', String(pageSize));
+
+  return params.toString();
+}
+
+/**
+ * Fetch action items from API
+ */
+async function fetchActionItems(
+  filters: ActionItemFilters,
+  sort: ActionItemSortOptions,
+  searchQuery: string,
+  page: number,
+  pageSize: number
+): Promise<ActionItemListResponse> {
+  const queryString = buildApiQueryString(filters, sort, searchQuery, page, pageSize);
+  const response = await fetch(`/api/action-items?${queryString}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch action items: ${response.statusText}`);
+  }
+
+  const result = await response.json() as ApiResponse<ActionItemListResponse>;
+
+  if (!result.success || result.data === undefined) {
+    throw new Error(result.error?.message ?? 'Failed to fetch action items');
+  }
+
+  return result.data;
+}
+
+/**
+ * Fetch action item statistics from API
+ */
+async function fetchStats(): Promise<ActionItemStatsData> {
+  const response = await fetch('/api/action-items/stats');
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch stats: ${response.statusText}`);
+  }
+
+  const result = await response.json() as ApiResponse<ActionItemStatsData>;
+
+  if (!result.success || result.data === undefined) {
+    throw new Error(result.error?.message ?? 'Failed to fetch stats');
+  }
+
+  return result.data;
+}
+
+/**
+ * Update action item status via API
+ */
+async function updateActionItemStatus(
+  id: string,
+  status: ActionItemStatus
+): Promise<ManagedActionItem> {
+  const response = await fetch(`/api/action-items/${id}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ status }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to update status: ${response.statusText}`);
+  }
+
+  const result = await response.json() as ApiResponse<ManagedActionItem>;
+
+  if (!result.success || result.data === undefined) {
+    throw new Error(result.error?.message ?? 'Failed to update status');
+  }
+
+  return result.data;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Convert API ManagedActionItem to component ManagedActionItem
+ */
+function toComponentActionItem(item: ActionItemListResponse['items'][number]): ManagedActionItem {
+  return {
+    id: item.id,
+    content: item.content,
+    assignee: item.assignee,
+    dueDate: item.dueDate,
+    priority: item.priority,
+    status: item.status,
+    relatedTopicId: item.relatedTopicId,
+    meeting: {
+      id: item.meetingId,
+      title: item.meetingTitle,
+    },
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+  };
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+/**
+ * Page Header Component
+ */
+function PageHeader({
+  total,
+  isLoading,
+}: {
+  readonly total: number;
+  readonly isLoading: boolean;
+}): JSX.Element {
+  return (
+    <div className="mb-6">
+      <h1 className="text-2xl font-bold text-slate-900 dark:text-white flex items-center gap-2">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="w-7 h-7 text-green-600"
+        >
+          <path
+            fillRule="evenodd"
+            d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zm13.36-1.814a.75.75 0 10-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 00-1.06 1.06l2.25 2.25a.75.75 0 001.14-.094l3.75-5.25z"
+            clipRule="evenodd"
+          />
+        </svg>
+        Action Items
+      </h1>
+      <p className="text-slate-600 dark:text-slate-400 mt-1">
+        {isLoading ? (
+          <span className="inline-block h-4 w-32 bg-gray-200 rounded animate-pulse" />
+        ) : (
+          `${total} items`
+        )}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Results Info Component
+ */
+function ResultsInfo({
+  currentPage,
+  totalPages,
+  total,
+  pageSize,
+}: {
+  readonly currentPage: number;
+  readonly totalPages: number;
+  readonly total: number;
+  readonly pageSize: number;
+}): JSX.Element {
+  const start = (currentPage - 1) * pageSize + 1;
+  const end = Math.min(currentPage * pageSize, total);
+
+  if (total === 0) {
+    return <></>;
+  }
+
+  return (
+    <div className="text-sm text-gray-500">
+      {total} items - showing {start}-{end}
+      {totalPages > 1 && ` (page ${currentPage} of ${totalPages})`}
+    </div>
+  );
+}
+
+/**
+ * Error display component
+ */
+function ErrorDisplay({
+  error,
+  onRetry,
+}: {
+  readonly error: string;
+  readonly onRetry: () => void;
+}): JSX.Element {
+  return (
+    <div className="text-center py-12">
+      <div className="text-red-500 mb-4">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="w-12 h-12 mx-auto"
+        >
+          <path
+            fillRule="evenodd"
+            d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm-1.72 6.97a.75.75 0 10-1.06 1.06L10.94 12l-1.72 1.72a.75.75 0 101.06 1.06L12 13.06l1.72 1.72a.75.75 0 101.06-1.06L13.06 12l1.72-1.72a.75.75 0 10-1.06-1.06L12 10.94l-1.72-1.72z"
+            clipRule="evenodd"
+          />
+        </svg>
+      </div>
+      <p className="text-gray-600 mb-4">{error}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+/**
+ * ActionItemsPageClient Component
+ *
+ * @description Client component that handles filtering, sorting, pagination, and status updates
+ *
+ * Features:
+ * - URL parameter synchronization
+ * - Optimistic status updates
+ * - Stats-based quick filtering
+ * - Debounced search
+ */
+export function ActionItemsPageClient({
+  initialData,
+  initialStats,
+}: ActionItemsPageClientProps): JSX.Element {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  // ============================================================================
+  // State
+  // ============================================================================
+
+  // Initialize state from URL params or defaults
+  const [filters, setFilters] = useState<ActionItemFilters>(() =>
+    parseFiltersFromParams(searchParams)
+  );
+  const [sort, setSort] = useState<ActionItemSortOptions>(() =>
+    parseSortFromParams(searchParams)
+  );
+  const [searchQuery, setSearchQuery] = useState<string>(
+    searchParams.get('search') ?? ''
+  );
+  const [pagination, setPagination] = useState(() =>
+    parsePaginationFromParams(searchParams)
+  );
+
+  // Data state
+  const [data, setData] = useState<ActionItemListResponse>(initialData);
+  const [stats, setStats] = useState<ActionItemStatsData>(initialStats);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Stats filter state (for quick filtering via stats cards)
+  const [activeStatsFilter, setActiveStatsFilter] = useState<
+    ActionItemStatus | 'overdue' | 'all'
+  >('all');
+
+  // ============================================================================
+  // Derived State
+  // ============================================================================
+
+  const items: readonly ManagedActionItem[] = useMemo(
+    () => data.items.map(toComponentActionItem),
+    [data.items]
+  );
+
+  const componentStats = useMemo(
+    () => ({
+      total: stats.total,
+      pending: stats.pending,
+      inProgress: stats.inProgress,
+      completed: stats.completed,
+      overdue: stats.overdue,
+    }),
+    [stats]
+  );
+
+  // ============================================================================
+  // URL Sync
+  // ============================================================================
+
+  /**
+   * Update URL when state changes
+   */
+  const updateUrl = useCallback(
+    (
+      newFilters: ActionItemFilters,
+      newSort: ActionItemSortOptions,
+      newSearch: string,
+      newPage: number,
+      newPageSize: number
+    ): void => {
+      const params = buildSearchParams(newFilters, newSort, newSearch, newPage, newPageSize);
+      const queryString = params.toString();
+      const newUrl = queryString !== '' ? `${pathname}?${queryString}` : pathname;
+
+      startTransition(() => {
+        // Use window.history to update URL without triggering Next.js router navigation
+        // This avoids type issues with Next.js typed routes while achieving the same effect
+        window.history.replaceState(null, '', newUrl);
+      });
+    },
+    [pathname]
+  );
+
+  // ============================================================================
+  // Data Fetching
+  // ============================================================================
+
+  /**
+   * Fetch data with current state
+   */
+  const fetchData = useCallback(async (): Promise<void> => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [newData, newStats] = await Promise.all([
+        fetchActionItems(filters, sort, searchQuery, pagination.page, pagination.pageSize),
+        fetchStats(),
+      ]);
+
+      setData(newData);
+      setStats(newStats);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'An error occurred';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [filters, sort, searchQuery, pagination.page, pagination.pageSize]);
+
+  /**
+   * Refetch data (for retry)
+   */
+  const handleRetry = useCallback((): void => {
+    void fetchData();
+  }, [fetchData]);
+
+  // ============================================================================
+  // Event Handlers
+  // ============================================================================
+
+  /**
+   * Handle filter changes
+   */
+  const handleFiltersChange = useCallback(
+    (newFilters: ActionItemFilters): void => {
+      setFilters(newFilters);
+      setPagination((prev) => ({ ...prev, page: 1 })); // Reset to first page
+      setActiveStatsFilter('all'); // Clear stats filter
+      updateUrl(newFilters, sort, searchQuery, 1, pagination.pageSize);
+    },
+    [sort, searchQuery, pagination.pageSize, updateUrl]
+  );
+
+  /**
+   * Handle sort changes
+   */
+  const handleSortChange = useCallback(
+    (newSort: ActionItemSortOptions): void => {
+      setSort(newSort);
+      updateUrl(filters, newSort, searchQuery, pagination.page, pagination.pageSize);
+    },
+    [filters, searchQuery, pagination, updateUrl]
+  );
+
+  /**
+   * Handle search changes (with debounce handled in component)
+   */
+  const handleSearchChange = useCallback(
+    (newQuery: string): void => {
+      setSearchQuery(newQuery);
+      setPagination((prev) => ({ ...prev, page: 1 })); // Reset to first page
+      updateUrl(filters, sort, newQuery, 1, pagination.pageSize);
+    },
+    [filters, sort, pagination.pageSize, updateUrl]
+  );
+
+  /**
+   * Handle page changes
+   */
+  const handlePageChange = useCallback(
+    (newPage: number): void => {
+      setPagination((prev) => ({ ...prev, page: newPage }));
+      updateUrl(filters, sort, searchQuery, newPage, pagination.pageSize);
+      // Scroll to top on page change
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    },
+    [filters, sort, searchQuery, pagination.pageSize, updateUrl]
+  );
+
+  /**
+   * Handle stats card click for quick filtering
+   */
+  const handleStatsFilterChange = useCallback(
+    (filter: ActionItemStatus | 'overdue' | 'all'): void => {
+      setActiveStatsFilter(filter);
+
+      let newFilters: ActionItemFilters;
+
+      if (filter === 'all') {
+        newFilters = createDefaultFilters();
+      } else if (filter === 'overdue') {
+        newFilters = {
+          ...createDefaultFilters(),
+          overdueOnly: true,
+        };
+      } else {
+        newFilters = {
+          ...createDefaultFilters(),
+          statuses: [filter],
+        };
+      }
+
+      setFilters(newFilters);
+      setPagination((prev) => ({ ...prev, page: 1 }));
+      updateUrl(newFilters, sort, searchQuery, 1, pagination.pageSize);
+    },
+    [sort, searchQuery, pagination.pageSize, updateUrl]
+  );
+
+  /**
+   * Handle status change with optimistic update
+   */
+  const handleStatusChange = useCallback(
+    (id: string, newStatus: ActionItemStatus): void => {
+      // Optimistic update
+      setData((prev) => ({
+        ...prev,
+        items: prev.items.map((item) =>
+          item.id === id
+            ? {
+                ...item,
+                status: newStatus,
+                updatedAt: new Date().toISOString(),
+                completedAt: newStatus === 'completed' ? new Date().toISOString() : item.completedAt,
+                isOverdue: newStatus === 'completed' ? false : item.isOverdue,
+              }
+            : item
+        ),
+      }));
+
+      // Optimistic stats update
+      setStats((prev) => {
+        const oldItem = data.items.find((item) => item.id === id);
+        if (oldItem === undefined) return prev;
+
+        const newStats = { ...prev };
+
+        // Decrement old status count
+        if (oldItem.status === 'pending') newStats.pending--;
+        else if (oldItem.status === 'in_progress') newStats.inProgress--;
+        else if (oldItem.status === 'completed') newStats.completed--;
+
+        // Increment new status count
+        if (newStatus === 'pending') newStats.pending++;
+        else if (newStatus === 'in_progress') newStats.inProgress++;
+        else if (newStatus === 'completed') newStats.completed++;
+
+        // Update overdue count
+        if (oldItem.isOverdue && newStatus === 'completed') {
+          newStats.overdue--;
+        }
+
+        return newStats;
+      });
+
+      // API call (fire and forget with error handling)
+      void (async (): Promise<void> => {
+        try {
+          await updateActionItemStatus(id, newStatus);
+        } catch (err) {
+          // Revert on error by refetching
+          console.error('Failed to update status:', err);
+          void fetchData();
+        }
+      })();
+    },
+    [data.items, fetchData]
+  );
+
+  // ============================================================================
+  // Effects
+  // ============================================================================
+
+  /**
+   * Fetch data when filters, sort, search, or pagination change
+   */
+  useEffect(() => {
+    // Skip initial fetch since we have initial data
+    const isInitialState =
+      filters.statuses.length === 0 &&
+      filters.priorities.length === 0 &&
+      filters.assigneeId === undefined &&
+      filters.meetingId === undefined &&
+      !filters.overdueOnly &&
+      sort.field === 'dueDate' &&
+      sort.direction === 'asc' &&
+      searchQuery === '' &&
+      pagination.page === 1;
+
+    if (!isInitialState) {
+      void fetchData();
+    }
+  }, [filters, sort, searchQuery, pagination.page, pagination.pageSize, fetchData]);
+
+  // ============================================================================
+  // Render
+  // ============================================================================
+
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <PageHeader total={data.pagination.total} isLoading={isLoading || isPending} />
+
+      {/* Stats Cards */}
+      <ActionItemStats
+        stats={componentStats}
+        onFilterChange={handleStatsFilterChange}
+        activeFilter={activeStatsFilter}
+      />
+
+      {/* Toolbar */}
+      <ActionItemToolbar
+        filters={filters}
+        sortOptions={sort}
+        searchQuery={searchQuery}
+        onFiltersChange={handleFiltersChange}
+        onSortChange={handleSortChange}
+        onSearchChange={handleSearchChange}
+      />
+
+      {/* Results Info */}
+      {!isLoading && error === null && (
+        <ResultsInfo
+          currentPage={data.pagination.page}
+          totalPages={data.pagination.totalPages}
+          total={data.pagination.total}
+          pageSize={data.pagination.pageSize}
+        />
+      )}
+
+      {/* Error State */}
+      {error !== null && (
+        <ErrorDisplay error={error} onRetry={handleRetry} />
+      )}
+
+      {/* Action Items List */}
+      {error === null && (
+        <ActionItemList
+          items={items}
+          isLoading={isLoading || isPending}
+          onStatusChange={handleStatusChange}
+          emptyMessage="No action items found. Try adjusting your filters."
+        />
+      )}
+
+      {/* Pagination */}
+      {!isLoading && error === null && data.pagination.totalPages > 1 && (
+        <div className="flex justify-center pt-4">
+          <Pagination
+            currentPage={data.pagination.page}
+            totalPages={data.pagination.totalPages}
+            onPageChange={handlePageChange}
+            disabled={isLoading || isPending}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ActionItemsPageClient;

--- a/src/app/(dashboard)/action-items/_components/index.ts
+++ b/src/app/(dashboard)/action-items/_components/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Action Items Page Components
+ * @module app/(dashboard)/action-items/_components
+ */
+
+export {
+  ActionItemsPageClient,
+  type ActionItemsPageClientProps,
+} from './action-items-page-client';

--- a/src/app/(dashboard)/action-items/loading.tsx
+++ b/src/app/(dashboard)/action-items/loading.tsx
@@ -1,0 +1,96 @@
+/**
+ * Action Items Page Loading State
+ * @module app/(dashboard)/action-items/loading
+ */
+
+import { ActionItemListSkeleton } from '@/components/action-items';
+
+/**
+ * Stats skeleton component
+ */
+function StatsSkeleton(): JSX.Element {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+      {Array.from({ length: 5 }).map((_, index) => (
+        <div
+          key={index}
+          className="rounded-lg p-4 bg-gray-50 animate-pulse"
+        >
+          <div className="flex items-center justify-between mb-2">
+            <div className="h-3 w-12 bg-gray-200 rounded" />
+            <div className="h-5 w-5 bg-gray-200 rounded" />
+          </div>
+          <div className="h-8 w-8 bg-gray-200 rounded" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Toolbar skeleton component
+ */
+function ToolbarSkeleton(): JSX.Element {
+  return (
+    <div className="flex flex-col gap-4 p-4 bg-white border border-gray-200 rounded-lg">
+      <div className="flex flex-wrap items-center gap-4">
+        {/* Filter dropdowns */}
+        <div className="flex-1 flex flex-wrap gap-3">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div
+              key={index}
+              className="h-10 w-32 bg-gray-200 rounded animate-pulse"
+            />
+          ))}
+        </div>
+        {/* Sort and search */}
+        <div className="flex items-center gap-3 flex-shrink-0">
+          <div className="h-10 w-32 bg-gray-200 rounded animate-pulse" />
+          <div className="h-10 w-64 bg-gray-200 rounded animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Loading component for action items page
+ *
+ * @description Displays skeleton loaders while the page is loading
+ */
+export default function ActionItemsLoading(): JSX.Element {
+  return (
+    <div className="space-y-6">
+      {/* Page Header skeleton */}
+      <div>
+        <div className="h-8 w-48 bg-gray-200 rounded animate-pulse mb-2" />
+        <div className="h-4 w-72 bg-gray-200 rounded animate-pulse" />
+      </div>
+
+      {/* Stats skeleton */}
+      <StatsSkeleton />
+
+      {/* Toolbar skeleton */}
+      <ToolbarSkeleton />
+
+      {/* Action items list skeleton */}
+      <ActionItemListSkeleton count={5} />
+
+      {/* Pagination skeleton */}
+      <div className="flex justify-center pt-4">
+        <div className="flex items-center gap-2">
+          <div className="h-10 w-20 bg-gray-200 rounded animate-pulse" />
+          <div className="flex gap-1">
+            {Array.from({ length: 5 }).map((_, index) => (
+              <div
+                key={index}
+                className="h-10 w-10 bg-gray-200 rounded animate-pulse"
+              />
+            ))}
+          </div>
+          <div className="h-10 w-20 bg-gray-200 rounded animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/action-items/page.tsx
+++ b/src/app/(dashboard)/action-items/page.tsx
@@ -1,0 +1,99 @@
+/**
+ * Action Items List Page - Display and manage action items
+ * @module app/(dashboard)/action-items/page
+ */
+
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { Suspense } from 'react';
+import { getSession } from '@/lib/auth/get-session';
+import { createActionItemService } from '@/services/action-item.service';
+import { ActionItemsPageClient } from './_components';
+import ActionItemsLoading from './loading';
+
+// ============================================================================
+// Metadata
+// ============================================================================
+
+/**
+ * Page metadata for SEO
+ */
+export const metadata: Metadata = {
+  title: 'Action Items',
+  description: 'View and manage your action items from meetings',
+};
+
+// ============================================================================
+// Data Fetching
+// ============================================================================
+
+/**
+ * Fetch initial data for the page
+ */
+async function getInitialData(): Promise<{
+  data: Awaited<ReturnType<ReturnType<typeof createActionItemService>['getActionItems']>>;
+  stats: Awaited<ReturnType<ReturnType<typeof createActionItemService>['getStats']>>;
+}> {
+  const service = createActionItemService();
+
+  // Fetch initial data with default parameters
+  const [data, stats] = await Promise.all([
+    service.getActionItems(
+      {}, // No filters
+      { field: 'dueDate', order: 'asc' }, // Default sort
+      { page: 1, pageSize: 20 } // Default pagination
+    ),
+    service.getStats(),
+  ]);
+
+  return { data, stats };
+}
+
+// ============================================================================
+// Page Component
+// ============================================================================
+
+/**
+ * Action Items Page (Server Component)
+ *
+ * @description Server component that:
+ * - Checks authentication
+ * - Fetches initial data
+ * - Passes data to client component for interactivity
+ *
+ * Features:
+ * - Server-side data fetching for fast initial load
+ * - Authentication protection
+ * - Loading state with Suspense
+ */
+async function ActionItemsPageContent(): Promise<React.ReactElement> {
+  // Authentication check
+  const session = await getSession();
+
+  if (session === null || !session.isAuthenticated) {
+    redirect('/login');
+  }
+
+  // Fetch initial data
+  const { data, stats } = await getInitialData();
+
+  return (
+    <ActionItemsPageClient
+      initialData={data}
+      initialStats={stats}
+    />
+  );
+}
+
+/**
+ * Action Items Page
+ *
+ * @description Main page component with Suspense boundary for loading state
+ */
+export default function ActionItemsPage(): JSX.Element {
+  return (
+    <Suspense fallback={<ActionItemsLoading />}>
+      <ActionItemsPageContent />
+    </Suspense>
+  );
+}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -21,6 +21,7 @@ interface DashboardLayoutProps {
 const NAV_LINKS = [
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/meetings', label: 'Meetings' },
+  { href: '/action-items', label: 'Action Items' },
   { href: '/settings', label: 'Settings' },
 ] as const;
 

--- a/src/app/(dashboard)/meetings/[id]/page.tsx
+++ b/src/app/(dashboard)/meetings/[id]/page.tsx
@@ -472,6 +472,7 @@ export default function MeetingDetailPage(): JSX.Element {
             <MinutesSection
               meetingId={meeting.id}
               meetingTitle={meeting.title}
+              meetingDate={meeting.startTime.split('T')[0] ?? ''}
               hasTranscript={state.hasTranscript}
             />
           </div>

--- a/src/app/api/action-items/[id]/route.ts
+++ b/src/app/api/action-items/[id]/route.ts
@@ -1,0 +1,398 @@
+/**
+ * Action Item Detail API endpoint - Get, update, delete single action item
+ * @module app/api/action-items/[id]/route
+ */
+
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSession } from '@/lib/auth/get-session';
+import {
+  createActionItemService,
+  ActionItemServiceError,
+  ActionItemNotFoundError,
+} from '@/services/action-item.service';
+import {
+  ActionItemStatusSchema,
+  PrioritySchema,
+  SpeakerSchema,
+} from '@/types/minutes';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * API response wrapper - success
+ */
+interface SuccessResponse<T> {
+  readonly success: true;
+  readonly data: T;
+}
+
+/**
+ * API response wrapper - error
+ */
+interface ErrorResponse {
+  readonly success: false;
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+    readonly details?: unknown;
+  };
+}
+
+/**
+ * Route context with params
+ */
+interface RouteContext {
+  readonly params: Promise<{
+    readonly id: string;
+  }>;
+}
+
+// ============================================================================
+// Validation Schemas
+// ============================================================================
+
+/**
+ * Request body schema for PATCH request
+ */
+const updateActionItemSchema = z.object({
+  /** New content */
+  content: z.string().min(1).optional(),
+  /** New assignee */
+  assignee: SpeakerSchema.optional(),
+  /** New due date (YYYY-MM-DD) */
+  dueDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be ISO date format YYYY-MM-DD')
+    .optional(),
+  /** New priority */
+  priority: PrioritySchema.optional(),
+  /** New status */
+  status: ActionItemStatusSchema.optional(),
+});
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Create success response
+ */
+function createSuccessResponse<T>(data: T): NextResponse<SuccessResponse<T>> {
+  return NextResponse.json({ success: true, data });
+}
+
+/**
+ * Create error response
+ */
+function createErrorResponse(
+  code: string,
+  message: string,
+  statusCode: number,
+  details?: unknown
+): NextResponse<ErrorResponse> {
+  const response: ErrorResponse = {
+    success: false,
+    error: {
+      code,
+      message,
+      ...(details !== undefined && { details }),
+    },
+  };
+
+  return NextResponse.json(response, { status: statusCode });
+}
+
+// ============================================================================
+// Route Handlers
+// ============================================================================
+
+/**
+ * GET /api/action-items/[id]
+ *
+ * Get a single action item by ID.
+ *
+ * Path Parameters:
+ * - id: string - Action item ID
+ *
+ * Response:
+ * - 200: ManagedActionItem
+ * - 401: Unauthorized
+ * - 404: Not found
+ * - 500: Internal Server Error
+ */
+export async function GET(
+  _request: Request,
+  context: RouteContext
+): Promise<Response> {
+  try {
+    // Authentication check
+    const session = await getSession();
+
+    if (session === null || !session.isAuthenticated) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Authentication required',
+        401
+      );
+    }
+
+    // Get action item ID from path params
+    const params = await context.params;
+    const actionItemId = params.id;
+
+    if (actionItemId === undefined || actionItemId.trim() === '') {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'Action item ID is required',
+        400
+      );
+    }
+
+    // Get action item
+    const service = createActionItemService();
+    const actionItem = await service.getActionItem(actionItemId);
+
+    if (actionItem === null) {
+      return createErrorResponse(
+        'NOT_FOUND',
+        `Action item not found: ${actionItemId}`,
+        404
+      );
+    }
+
+    return createSuccessResponse(actionItem);
+  } catch (error) {
+    console.error('[GET /api/action-items/[id]] Error:', error);
+
+    if (error instanceof ActionItemNotFoundError) {
+      return createErrorResponse('NOT_FOUND', error.message, 404);
+    }
+
+    if (error instanceof ActionItemServiceError) {
+      return createErrorResponse(
+        error.code,
+        error.message,
+        error.statusCode,
+        error.details
+      );
+    }
+
+    return createErrorResponse(
+      'INTERNAL_ERROR',
+      'An unexpected error occurred',
+      500
+    );
+  }
+}
+
+/**
+ * PATCH /api/action-items/[id]
+ *
+ * Update an action item.
+ *
+ * Path Parameters:
+ * - id: string - Action item ID
+ *
+ * Request Body:
+ * {
+ *   "content"?: string,
+ *   "assignee"?: Speaker,
+ *   "dueDate"?: string (YYYY-MM-DD),
+ *   "priority"?: Priority,
+ *   "status"?: ActionItemStatus
+ * }
+ *
+ * Response:
+ * - 200: Updated ManagedActionItem
+ * - 400: Invalid request body
+ * - 401: Unauthorized
+ * - 404: Not found
+ * - 500: Internal Server Error
+ */
+export async function PATCH(
+  request: Request,
+  context: RouteContext
+): Promise<Response> {
+  try {
+    // Authentication check
+    const session = await getSession();
+
+    if (session === null || !session.isAuthenticated) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Authentication required',
+        401
+      );
+    }
+
+    // Get action item ID from path params
+    const params = await context.params;
+    const actionItemId = params.id;
+
+    if (actionItemId === undefined || actionItemId.trim() === '') {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'Action item ID is required',
+        400
+      );
+    }
+
+    // Parse and validate request body
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'Invalid JSON in request body',
+        400
+      );
+    }
+
+    const validation = updateActionItemSchema.safeParse(body);
+    if (!validation.success) {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'Invalid request body',
+        400,
+        { validationErrors: validation.error.errors }
+      );
+    }
+
+    const validatedData = validation.data;
+
+    // Build updates object with only defined properties
+    const updates: Partial<
+      Pick<
+        import('@/types/action-item').ManagedActionItem,
+        'content' | 'assignee' | 'dueDate' | 'priority' | 'status'
+      >
+    > = {};
+
+    if (validatedData.content !== undefined) {
+      updates.content = validatedData.content;
+    }
+    if (validatedData.assignee !== undefined) {
+      updates.assignee = validatedData.assignee;
+    }
+    if (validatedData.dueDate !== undefined) {
+      updates.dueDate = validatedData.dueDate;
+    }
+    if (validatedData.priority !== undefined) {
+      updates.priority = validatedData.priority;
+    }
+    if (validatedData.status !== undefined) {
+      updates.status = validatedData.status;
+    }
+
+    // Check if there are any updates
+    if (Object.keys(updates).length === 0) {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'No update fields provided',
+        400
+      );
+    }
+
+    // Update action item
+    const service = createActionItemService();
+    const updatedItem = await service.updateActionItem(actionItemId, updates);
+
+    return createSuccessResponse(updatedItem);
+  } catch (error) {
+    console.error('[PATCH /api/action-items/[id]] Error:', error);
+
+    if (error instanceof ActionItemNotFoundError) {
+      return createErrorResponse('NOT_FOUND', error.message, 404);
+    }
+
+    if (error instanceof ActionItemServiceError) {
+      return createErrorResponse(
+        error.code,
+        error.message,
+        error.statusCode,
+        error.details
+      );
+    }
+
+    return createErrorResponse(
+      'INTERNAL_ERROR',
+      'An unexpected error occurred',
+      500
+    );
+  }
+}
+
+/**
+ * DELETE /api/action-items/[id]
+ *
+ * Delete an action item.
+ *
+ * Path Parameters:
+ * - id: string - Action item ID
+ *
+ * Response:
+ * - 200: { message: "Deleted successfully" }
+ * - 401: Unauthorized
+ * - 404: Not found
+ * - 500: Internal Server Error
+ */
+export async function DELETE(
+  _request: Request,
+  context: RouteContext
+): Promise<Response> {
+  try {
+    // Authentication check
+    const session = await getSession();
+
+    if (session === null || !session.isAuthenticated) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Authentication required',
+        401
+      );
+    }
+
+    // Get action item ID from path params
+    const params = await context.params;
+    const actionItemId = params.id;
+
+    if (actionItemId === undefined || actionItemId.trim() === '') {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'Action item ID is required',
+        400
+      );
+    }
+
+    // Delete action item
+    const service = createActionItemService();
+    await service.deleteActionItem(actionItemId);
+
+    return createSuccessResponse({ message: 'Deleted successfully' });
+  } catch (error) {
+    console.error('[DELETE /api/action-items/[id]] Error:', error);
+
+    if (error instanceof ActionItemNotFoundError) {
+      return createErrorResponse('NOT_FOUND', error.message, 404);
+    }
+
+    if (error instanceof ActionItemServiceError) {
+      return createErrorResponse(
+        error.code,
+        error.message,
+        error.statusCode,
+        error.details
+      );
+    }
+
+    return createErrorResponse(
+      'INTERNAL_ERROR',
+      'An unexpected error occurred',
+      500
+    );
+  }
+}

--- a/src/app/api/action-items/batch/route.ts
+++ b/src/app/api/action-items/batch/route.ts
@@ -1,0 +1,188 @@
+/**
+ * Action Items Batch API endpoint - Batch update action items
+ * @module app/api/action-items/batch/route
+ */
+
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSession } from '@/lib/auth/get-session';
+import {
+  createActionItemService,
+  ActionItemServiceError,
+} from '@/services/action-item.service';
+import { ActionItemStatusUpdateSchema } from '@/types/action-item';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * API response wrapper - success
+ */
+interface SuccessResponse<T> {
+  readonly success: true;
+  readonly data: T;
+}
+
+/**
+ * API response wrapper - error
+ */
+interface ErrorResponse {
+  readonly success: false;
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+    readonly details?: unknown;
+  };
+}
+
+// ============================================================================
+// Validation Schemas
+// ============================================================================
+
+/**
+ * Request body schema for batch update
+ */
+const batchUpdateSchema = z.object({
+  /** Array of updates to apply */
+  updates: z
+    .array(ActionItemStatusUpdateSchema)
+    .min(1, 'At least one update is required')
+    .max(100, 'Maximum 100 updates per request'),
+});
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Create success response
+ */
+function createSuccessResponse<T>(data: T): NextResponse<SuccessResponse<T>> {
+  return NextResponse.json({ success: true, data });
+}
+
+/**
+ * Create error response
+ */
+function createErrorResponse(
+  code: string,
+  message: string,
+  statusCode: number,
+  details?: unknown
+): NextResponse<ErrorResponse> {
+  const response: ErrorResponse = {
+    success: false,
+    error: {
+      code,
+      message,
+      ...(details !== undefined && { details }),
+    },
+  };
+
+  return NextResponse.json(response, { status: statusCode });
+}
+
+// ============================================================================
+// Route Handlers
+// ============================================================================
+
+/**
+ * PATCH /api/action-items/batch
+ *
+ * Batch update action item statuses.
+ *
+ * Request Body:
+ * {
+ *   "updates": [
+ *     { "id": "action_xxx", "status": "completed" },
+ *     { "id": "action_yyy", "status": "in_progress" }
+ *   ]
+ * }
+ *
+ * Response:
+ * - 200: Array of updated ManagedActionItems
+ * - 400: Invalid request body or partial failure
+ * - 401: Unauthorized
+ * - 500: Internal Server Error
+ */
+export async function PATCH(request: Request): Promise<Response> {
+  try {
+    // Authentication check
+    const session = await getSession();
+
+    if (session === null || !session.isAuthenticated) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Authentication required',
+        401
+      );
+    }
+
+    // Parse and validate request body
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'Invalid JSON in request body',
+        400
+      );
+    }
+
+    const validation = batchUpdateSchema.safeParse(body);
+    if (!validation.success) {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'Invalid request body',
+        400,
+        { validationErrors: validation.error.errors }
+      );
+    }
+
+    const { updates } = validation.data;
+
+    // Perform batch update
+    const service = createActionItemService();
+
+    try {
+      const updatedItems = await service.updateStatusBatch(updates);
+      return createSuccessResponse({
+        updated: updatedItems,
+        count: updatedItems.length,
+      });
+    } catch (error) {
+      // Handle partial failure specifically
+      if (
+        error instanceof ActionItemServiceError &&
+        error.code === 'BATCH_UPDATE_PARTIAL_FAILURE'
+      ) {
+        return createErrorResponse(
+          error.code,
+          error.message,
+          error.statusCode,
+          error.details
+        );
+      }
+      throw error;
+    }
+  } catch (error) {
+    console.error('[PATCH /api/action-items/batch] Error:', error);
+
+    if (error instanceof ActionItemServiceError) {
+      return createErrorResponse(
+        error.code,
+        error.message,
+        error.statusCode,
+        error.details
+      );
+    }
+
+    return createErrorResponse(
+      'INTERNAL_ERROR',
+      'An unexpected error occurred',
+      500
+    );
+  }
+}

--- a/src/app/api/action-items/route.ts
+++ b/src/app/api/action-items/route.ts
@@ -1,0 +1,392 @@
+/**
+ * Action Items API endpoint - List and create action items
+ * @module app/api/action-items/route
+ */
+
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSession } from '@/lib/auth/get-session';
+import {
+  createActionItemService,
+  ActionItemServiceError,
+} from '@/services/action-item.service';
+import {
+  ActionItemSortFieldSchema,
+  SortOrderSchema,
+} from '@/types/action-item';
+import {
+  MinutesSchema,
+  ActionItemStatusSchema,
+  PrioritySchema,
+} from '@/types/minutes';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * API response wrapper - success
+ */
+interface SuccessResponse<T> {
+  readonly success: true;
+  readonly data: T;
+}
+
+/**
+ * API response wrapper - error
+ */
+interface ErrorResponse {
+  readonly success: false;
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+    readonly details?: unknown;
+  };
+}
+
+// ============================================================================
+// Validation Schemas
+// ============================================================================
+
+/**
+ * Query parameters schema for GET request
+ */
+const listQuerySchema = z.object({
+  /** Filter by status (comma-separated) */
+  status: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (val === undefined || val === '') return undefined;
+      const statuses = val.split(',').map((s) => s.trim());
+      const result = z.array(ActionItemStatusSchema).safeParse(statuses);
+      return result.success ? result.data : undefined;
+    }),
+  /** Filter by priority (comma-separated) */
+  priority: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (val === undefined || val === '') return undefined;
+      const priorities = val.split(',').map((p) => p.trim());
+      const result = z.array(PrioritySchema).safeParse(priorities);
+      return result.success ? result.data : undefined;
+    }),
+  /** Filter by assignee ID */
+  assigneeId: z
+    .string()
+    .optional()
+    .transform((val) => (val === '' ? undefined : val)),
+  /** Filter by meeting ID */
+  meetingId: z
+    .string()
+    .optional()
+    .transform((val) => (val === '' ? undefined : val)),
+  /** Filter by overdue status */
+  isOverdue: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (val === undefined || val === '') return undefined;
+      return val === 'true';
+    }),
+  /** Text search query */
+  searchQuery: z
+    .string()
+    .optional()
+    .transform((val) => (val === '' ? undefined : val)),
+  /** Sort field */
+  sortField: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (val === undefined || val === '') return 'dueDate';
+      const result = ActionItemSortFieldSchema.safeParse(val);
+      return result.success ? result.data : 'dueDate';
+    }),
+  /** Sort order */
+  sortOrder: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (val === undefined || val === '') return 'asc';
+      const result = SortOrderSchema.safeParse(val);
+      return result.success ? result.data : 'asc';
+    }),
+  /** Page number (1-indexed) */
+  page: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (val === undefined || val === '') return 1;
+      const parsed = parseInt(val, 10);
+      return isNaN(parsed) || parsed < 1 ? 1 : parsed;
+    }),
+  /** Page size */
+  pageSize: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (val === undefined || val === '') return 20;
+      const parsed = parseInt(val, 10);
+      if (isNaN(parsed) || parsed < 1) return 20;
+      return Math.min(parsed, 100); // Max 100
+    }),
+});
+
+/**
+ * Request body schema for POST request (create from minutes)
+ */
+const createFromMinutesSchema = z.object({
+  /** Minutes data containing action items */
+  minutes: MinutesSchema,
+  /** Meeting information */
+  meeting: z.object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  }),
+});
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Create success response
+ */
+function createSuccessResponse<T>(data: T): NextResponse<SuccessResponse<T>> {
+  return NextResponse.json({ success: true, data });
+}
+
+/**
+ * Create error response
+ */
+function createErrorResponse(
+  code: string,
+  message: string,
+  statusCode: number,
+  details?: unknown
+): NextResponse<ErrorResponse> {
+  const response: ErrorResponse = {
+    success: false,
+    error: {
+      code,
+      message,
+      ...(details !== undefined && { details }),
+    },
+  };
+
+  return NextResponse.json(response, { status: statusCode });
+}
+
+/**
+ * Parse query parameters from URL
+ */
+function parseQueryParams(url: URL): z.infer<typeof listQuerySchema> {
+  const rawParams: Record<string, string | undefined> = {};
+
+  const paramNames = [
+    'status',
+    'priority',
+    'assigneeId',
+    'meetingId',
+    'isOverdue',
+    'searchQuery',
+    'sortField',
+    'sortOrder',
+    'page',
+    'pageSize',
+  ] as const;
+
+  for (const name of paramNames) {
+    const value = url.searchParams.get(name);
+    if (value !== null) {
+      rawParams[name] = value;
+    }
+  }
+
+  return listQuerySchema.parse(rawParams);
+}
+
+// ============================================================================
+// Route Handlers
+// ============================================================================
+
+/**
+ * GET /api/action-items
+ *
+ * List action items with pagination, filtering, and sorting.
+ *
+ * Query Parameters:
+ * - status: string[] (comma-separated) - Filter by status
+ * - priority: string[] (comma-separated) - Filter by priority
+ * - assigneeId: string - Filter by assignee ID
+ * - meetingId: string - Filter by meeting ID
+ * - isOverdue: boolean - Filter by overdue status
+ * - searchQuery: string - Text search
+ * - sortField: 'dueDate' | 'priority' | 'status' | 'createdAt' | 'meetingDate'
+ * - sortOrder: 'asc' | 'desc'
+ * - page: number (default: 1)
+ * - pageSize: number (default: 20, max: 100)
+ *
+ * Response:
+ * - 200: ActionItemListResponse
+ * - 400: Invalid parameters
+ * - 401: Unauthorized
+ * - 500: Internal Server Error
+ */
+export async function GET(request: Request): Promise<Response> {
+  try {
+    // Authentication check
+    const session = await getSession();
+
+    if (session === null || !session.isAuthenticated) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Authentication required',
+        401
+      );
+    }
+
+    // Parse and validate query parameters
+    const url = new URL(request.url);
+    let params: z.infer<typeof listQuerySchema>;
+
+    try {
+      params = parseQueryParams(url);
+    } catch (error) {
+      const message =
+        error instanceof z.ZodError
+          ? error.errors.map((e) => e.message).join(', ')
+          : 'Invalid query parameters';
+
+      return createErrorResponse('INVALID_PARAMS', message, 400, {
+        validationError: error instanceof z.ZodError ? error.errors : undefined,
+      });
+    }
+
+    // Create service and fetch action items
+    const service = createActionItemService();
+
+    const result = await service.getActionItems(
+      {
+        status: params.status,
+        priority: params.priority,
+        assigneeId: params.assigneeId,
+        meetingId: params.meetingId,
+        isOverdue: params.isOverdue,
+        searchQuery: params.searchQuery,
+      },
+      {
+        field: params.sortField,
+        order: params.sortOrder,
+      },
+      {
+        page: params.page,
+        pageSize: params.pageSize,
+      }
+    );
+
+    return createSuccessResponse(result);
+  } catch (error) {
+    console.error('[GET /api/action-items] Error:', error);
+
+    if (error instanceof ActionItemServiceError) {
+      return createErrorResponse(
+        error.code,
+        error.message,
+        error.statusCode,
+        error.details
+      );
+    }
+
+    return createErrorResponse(
+      'INTERNAL_ERROR',
+      'An unexpected error occurred',
+      500
+    );
+  }
+}
+
+/**
+ * POST /api/action-items
+ *
+ * Create action items from minutes.
+ *
+ * Request Body:
+ * {
+ *   "minutes": Minutes,
+ *   "meeting": { "id": string, "title": string, "date": string }
+ * }
+ *
+ * Response:
+ * - 201: Created action items
+ * - 400: Invalid request body
+ * - 401: Unauthorized
+ * - 500: Internal Server Error
+ */
+export async function POST(request: Request): Promise<Response> {
+  try {
+    // Authentication check
+    const session = await getSession();
+
+    if (session === null || !session.isAuthenticated) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Authentication required',
+        401
+      );
+    }
+
+    // Parse and validate request body
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'Invalid JSON in request body',
+        400
+      );
+    }
+
+    const validation = createFromMinutesSchema.safeParse(body);
+    if (!validation.success) {
+      return createErrorResponse(
+        'INVALID_PARAMS',
+        'Invalid request body',
+        400,
+        { validationErrors: validation.error.errors }
+      );
+    }
+
+    const { minutes, meeting } = validation.data;
+
+    // Create service and create action items
+    const service = createActionItemService();
+    const createdItems = await service.createFromMinutes(minutes, meeting);
+
+    return NextResponse.json(
+      { success: true, data: createdItems },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error('[POST /api/action-items] Error:', error);
+
+    if (error instanceof ActionItemServiceError) {
+      return createErrorResponse(
+        error.code,
+        error.message,
+        error.statusCode,
+        error.details
+      );
+    }
+
+    return createErrorResponse(
+      'INTERNAL_ERROR',
+      'An unexpected error occurred',
+      500
+    );
+  }
+}

--- a/src/app/api/action-items/stats/route.ts
+++ b/src/app/api/action-items/stats/route.ts
@@ -1,0 +1,126 @@
+/**
+ * Action Items Stats API endpoint - Get action item statistics
+ * @module app/api/action-items/stats/route
+ */
+
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth/get-session';
+import {
+  createActionItemService,
+  ActionItemServiceError,
+} from '@/services/action-item.service';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * API response wrapper - success
+ */
+interface SuccessResponse<T> {
+  readonly success: true;
+  readonly data: T;
+}
+
+/**
+ * API response wrapper - error
+ */
+interface ErrorResponse {
+  readonly success: false;
+  readonly error: {
+    readonly code: string;
+    readonly message: string;
+    readonly details?: unknown;
+  };
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Create success response
+ */
+function createSuccessResponse<T>(data: T): NextResponse<SuccessResponse<T>> {
+  return NextResponse.json({ success: true, data });
+}
+
+/**
+ * Create error response
+ */
+function createErrorResponse(
+  code: string,
+  message: string,
+  statusCode: number,
+  details?: unknown
+): NextResponse<ErrorResponse> {
+  const response: ErrorResponse = {
+    success: false,
+    error: {
+      code,
+      message,
+      ...(details !== undefined && { details }),
+    },
+  };
+
+  return NextResponse.json(response, { status: statusCode });
+}
+
+// ============================================================================
+// Route Handlers
+// ============================================================================
+
+/**
+ * GET /api/action-items/stats
+ *
+ * Get statistics about all action items.
+ *
+ * Response:
+ * - 200: ActionItemStats
+ *   {
+ *     "total": number,
+ *     "pending": number,
+ *     "inProgress": number,
+ *     "completed": number,
+ *     "overdue": number
+ *   }
+ * - 401: Unauthorized
+ * - 500: Internal Server Error
+ */
+export async function GET(_request: Request): Promise<Response> {
+  try {
+    // Authentication check
+    const session = await getSession();
+
+    if (session === null || !session.isAuthenticated) {
+      return createErrorResponse(
+        'UNAUTHORIZED',
+        'Authentication required',
+        401
+      );
+    }
+
+    // Get statistics
+    const service = createActionItemService();
+    const stats = await service.getStats();
+
+    return createSuccessResponse(stats);
+  } catch (error) {
+    console.error('[GET /api/action-items/stats] Error:', error);
+
+    if (error instanceof ActionItemServiceError) {
+      return createErrorResponse(
+        error.code,
+        error.message,
+        error.statusCode,
+        error.details
+      );
+    }
+
+    return createErrorResponse(
+      'INTERNAL_ERROR',
+      'An unexpected error occurred',
+      500
+    );
+  }
+}

--- a/src/components/action-items/ActionItemCard.tsx
+++ b/src/components/action-items/ActionItemCard.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+/**
+ * ActionItemCard component
+ * @module components/action-items/ActionItemCard
+ */
+
+import { useCallback, useMemo } from 'react';
+import { Avatar } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import type { ActionItemCardProps, Priority, ActionItemStatus } from './types';
+
+/**
+ * Get priority badge configuration
+ */
+function getPriorityConfig(priority: Priority): {
+  label: string;
+  className: string;
+} {
+  const config: Record<Priority, { label: string; className: string }> = {
+    high: { label: '高', className: 'bg-red-100 text-red-700' },
+    medium: { label: '中', className: 'bg-yellow-100 text-yellow-700' },
+    low: { label: '低', className: 'bg-gray-100 text-gray-600' },
+  };
+  return config[priority];
+}
+
+/**
+ * Get status badge configuration
+ */
+function getStatusConfig(status: ActionItemStatus): {
+  label: string;
+  className: string;
+} {
+  const config: Record<ActionItemStatus, { label: string; className: string }> = {
+    pending: { label: '未着手', className: 'bg-gray-100 text-gray-700' },
+    in_progress: { label: '進行中', className: 'bg-blue-100 text-blue-700' },
+    completed: { label: '完了', className: 'bg-green-100 text-green-700' },
+  };
+  return config[status];
+}
+
+/**
+ * Calculate days until due date
+ * @returns Object with days count and overdue status
+ */
+function getDueDateInfo(dueDate: string | undefined): {
+  text: string;
+  isOverdue: boolean;
+  daysUntil: number | null;
+} {
+  if (dueDate === undefined || dueDate === '') {
+    return { text: '期限なし', isOverdue: false, daysUntil: null };
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const due = new Date(dueDate);
+  due.setHours(0, 0, 0, 0);
+
+  const diffTime = due.getTime() - today.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+  if (diffDays < 0) {
+    return {
+      text: `${Math.abs(diffDays)}日超過`,
+      isOverdue: true,
+      daysUntil: diffDays,
+    };
+  } else if (diffDays === 0) {
+    return { text: '今日まで', isOverdue: false, daysUntil: 0 };
+  } else if (diffDays === 1) {
+    return { text: '明日まで', isOverdue: false, daysUntil: 1 };
+  } else {
+    return { text: `あと${diffDays}日`, isOverdue: false, daysUntil: diffDays };
+  }
+}
+
+/**
+ * Format date to display format (MM/DD)
+ */
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  return `${month}/${day}`;
+}
+
+/**
+ * ActionItemCard component
+ *
+ * @description Displays a single action item with status, priority, assignee, and due date
+ * @example
+ * ```tsx
+ * <ActionItemCard
+ *   item={actionItem}
+ *   onStatusChange={(id, status) => updateStatus(id, status)}
+ *   onEdit={(item) => openEditModal(item)}
+ * />
+ * ```
+ */
+export function ActionItemCard({
+  item,
+  onStatusChange,
+  onEdit,
+  onClick,
+  className = '',
+}: ActionItemCardProps): JSX.Element {
+  const priorityConfig = getPriorityConfig(item.priority);
+  const statusConfig = getStatusConfig(item.status);
+  const dueDateInfo = useMemo(() => getDueDateInfo(item.dueDate), [item.dueDate]);
+  const isCompleted = item.status === 'completed';
+
+  const handleComplete = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onStatusChange(item.id, 'completed');
+    },
+    [item.id, onStatusChange]
+  );
+
+  const handleEdit = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onEdit?.(item);
+    },
+    [item, onEdit]
+  );
+
+  const handleClick = useCallback(() => {
+    onClick?.(item);
+  }, [item, onClick]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick?.(item);
+      }
+    },
+    [item, onClick]
+  );
+
+  return (
+    <div
+      className={`
+        border border-gray-200 rounded-lg bg-white p-4
+        hover:border-gray-300 hover:shadow-sm transition-all
+        ${onClick ? 'cursor-pointer' : ''}
+        ${isCompleted ? 'opacity-60' : ''}
+        ${className}
+      `}
+      onClick={onClick ? handleClick : undefined}
+      onKeyDown={onClick ? handleKeyDown : undefined}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      aria-label={`アクションアイテム: ${item.content}`}
+    >
+      {/* Header Row: Title and Due Date */}
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="flex items-start gap-2 flex-1 min-w-0">
+          {/* Warning icon for overdue items */}
+          {dueDateInfo.isOverdue && !isCompleted && (
+            <span
+              className="text-red-500 flex-shrink-0 mt-0.5"
+              aria-label="期限切れ"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="w-5 h-5"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </span>
+          )}
+          <h3
+            className={`
+              text-sm font-medium text-gray-900 line-clamp-2
+              ${isCompleted ? 'line-through text-gray-500' : ''}
+            `}
+          >
+            {item.content}
+          </h3>
+        </div>
+
+        {/* Due Date Display */}
+        {item.dueDate !== undefined && item.dueDate !== '' && (
+          <div className="flex-shrink-0 text-right">
+            <div className="text-xs text-gray-500">
+              期限: {formatDate(item.dueDate)}
+            </div>
+            <div
+              className={`
+                text-xs font-medium
+                ${dueDateInfo.isOverdue && !isCompleted ? 'text-red-600' : 'text-gray-600'}
+              `}
+            >
+              ({dueDateInfo.text})
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Meta Row: Assignee, Priority, Meeting */}
+      <div className="flex items-center flex-wrap gap-2 mb-3 text-sm text-gray-600">
+        {/* Assignee */}
+        {item.assignee && (
+          <div className="flex items-center gap-1.5">
+            <span className="text-gray-400">担当:</span>
+            <div className="flex items-center gap-1">
+              <Avatar name={item.assignee.name} size="sm" />
+              <span className="text-gray-700">{item.assignee.name}</span>
+            </div>
+          </div>
+        )}
+
+        {/* Priority Badge */}
+        <div className="flex items-center gap-1.5">
+          <span className="text-gray-400">優先度:</span>
+          <Badge className={priorityConfig.className}>
+            {priorityConfig.label}
+          </Badge>
+        </div>
+
+        {/* Status Badge */}
+        <Badge className={statusConfig.className}>
+          {statusConfig.label}
+        </Badge>
+
+        {/* Meeting Link */}
+        {item.meeting && (
+          <div className="flex items-center gap-1.5">
+            <span className="text-gray-400">会議:</span>
+            <span className="text-blue-600 hover:underline">
+              {item.meeting.title}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex items-center gap-2">
+        {!isCompleted && (
+          <button
+            type="button"
+            onClick={handleComplete}
+            className="
+              inline-flex items-center px-3 py-1.5
+              text-xs font-medium text-green-700 bg-green-50
+              border border-green-200 rounded-md
+              hover:bg-green-100 transition-colors
+              focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-1
+            "
+            aria-label={`${item.content}を完了にする`}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-4 h-4 mr-1"
+            >
+              <path
+                fillRule="evenodd"
+                d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+                clipRule="evenodd"
+              />
+            </svg>
+            完了にする
+          </button>
+        )}
+
+        {onEdit && (
+          <button
+            type="button"
+            onClick={handleEdit}
+            className="
+              inline-flex items-center px-3 py-1.5
+              text-xs font-medium text-gray-700 bg-gray-50
+              border border-gray-200 rounded-md
+              hover:bg-gray-100 transition-colors
+              focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-1
+            "
+            aria-label={`${item.content}を編集`}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="w-4 h-4 mr-1"
+            >
+              <path d="M2.695 14.763l-1.262 3.154a.5.5 0 00.65.65l3.155-1.262a4 4 0 001.343-.885L17.5 5.5a2.121 2.121 0 00-3-3L3.58 13.42a4 4 0 00-.885 1.343z" />
+            </svg>
+            編集
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/action-items/ActionItemEmptyState.tsx
+++ b/src/components/action-items/ActionItemEmptyState.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+/**
+ * ActionItemEmptyState component
+ * @module components/action-items/ActionItemEmptyState
+ */
+
+import type { ActionItemEmptyStateProps } from './types';
+
+/**
+ * ActionItemEmptyState component
+ *
+ * @description Displays an empty state when no action items are available
+ * @example
+ * ```tsx
+ * <ActionItemEmptyState />
+ * <ActionItemEmptyState message="フィルター条件に一致するアイテムがありません" />
+ * ```
+ */
+export function ActionItemEmptyState({
+  message = 'アクションアイテムがありません',
+  className = '',
+}: ActionItemEmptyStateProps): JSX.Element {
+  return (
+    <div
+      className={`
+        flex flex-col items-center justify-center py-12 px-4
+        text-center
+        ${className}
+      `}
+      role="status"
+      aria-live="polite"
+    >
+      {/* Empty state icon */}
+      <div className="mb-4 text-gray-300">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1}
+          stroke="currentColor"
+          className="w-16 h-16"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9 12h3.75M9 15h3.75M9 18h3.75m3 .75H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08m-5.801 0c-.065.21-.1.433-.1.664 0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75 2.25 2.25 0 00-.1-.664m-5.8 0A2.251 2.251 0 0113.5 2.25H15c1.012 0 1.867.668 2.15 1.586m-5.8 0c-.376.023-.75.05-1.124.08C9.095 4.01 8.25 4.973 8.25 6.108V8.25m0 0H4.875c-.621 0-1.125.504-1.125 1.125v11.25c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V9.375c0-.621-.504-1.125-1.125-1.125H8.25zM6.75 12h.008v.008H6.75V12zm0 3h.008v.008H6.75V15zm0 3h.008v.008H6.75V18z"
+          />
+        </svg>
+      </div>
+
+      {/* Message */}
+      <h3 className="text-base font-medium text-gray-600 mb-1">
+        {message}
+      </h3>
+
+      {/* Subtitle */}
+      <p className="text-sm text-gray-400">
+        会議で決まったタスクがここに表示されます
+      </p>
+    </div>
+  );
+}

--- a/src/components/action-items/ActionItemFilters.tsx
+++ b/src/components/action-items/ActionItemFilters.tsx
@@ -1,0 +1,487 @@
+'use client';
+
+import { memo, useCallback, useState, useRef, useEffect } from 'react';
+import type { Speaker } from '@/types/minutes';
+import type {
+  ActionItemFilters as FilterState,
+  MeetingReference,
+  ActionItemStatus,
+  Priority,
+} from './types';
+import {
+  STATUS_LABELS,
+  PRIORITY_LABELS,
+  hasActiveFilters,
+  createDefaultFilters,
+} from './types';
+
+/**
+ * Props for ActionItemFilters component
+ */
+export interface ActionItemFiltersProps {
+  /** Current filter state */
+  readonly filters: FilterState;
+  /** Callback when filters change */
+  readonly onChange: (filters: FilterState) => void;
+  /** Available assignees for filter dropdown */
+  readonly assignees?: readonly Speaker[] | undefined;
+  /** Available meetings for filter dropdown */
+  readonly meetings?: readonly MeetingReference[] | undefined;
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Multi-select dropdown component for status/priority filters
+ */
+interface MultiSelectDropdownProps<T extends string> {
+  readonly label: string;
+  readonly options: readonly { readonly value: T; readonly label: string }[];
+  readonly selected: readonly T[];
+  readonly onChange: (selected: readonly T[]) => void;
+  readonly className?: string | undefined;
+}
+
+function MultiSelectDropdown<T extends string>({
+  label,
+  options,
+  selected,
+  onChange,
+  className = '',
+}: MultiSelectDropdownProps<T>): JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent): void => {
+      if (
+        containerRef.current !== null &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return (): void => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const handleToggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  const handleOptionClick = useCallback(
+    (value: T) => {
+      if (selected.includes(value)) {
+        onChange(selected.filter((v) => v !== value));
+      } else {
+        onChange([...selected, value]);
+      }
+    },
+    [selected, onChange]
+  );
+
+  const displayText =
+    selected.length === 0
+      ? label
+      : selected.length === 1
+        ? options.find((o) => o.value === selected[0])?.label ?? label
+        : `${selected.length} selected`;
+
+  return (
+    <div ref={containerRef} className={`relative ${className}`}>
+      <button
+        type="button"
+        onClick={handleToggle}
+        className={`
+          flex items-center justify-between gap-2 px-3 py-2 text-sm
+          border border-lark-border rounded-lg
+          bg-white text-lark-text
+          transition-colors duration-150
+          hover:border-lark-primary cursor-pointer
+          ${isOpen ? 'ring-2 ring-lark-primary border-transparent' : ''}
+          ${selected.length > 0 ? 'bg-lark-primary/5' : ''}
+        `}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+      >
+        <span className={selected.length === 0 ? 'text-gray-500' : ''}>
+          {displayText}
+        </span>
+        <svg
+          className={`w-4 h-4 text-gray-400 transition-transform duration-150 ${
+            isOpen ? 'transform rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          className="absolute z-50 mt-1 w-48 bg-white border border-lark-border rounded-lg shadow-lg py-1"
+          role="listbox"
+          aria-multiselectable="true"
+        >
+          {options.map((option) => {
+            const isSelected = selected.includes(option.value);
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => handleOptionClick(option.value)}
+                className={`
+                  w-full flex items-center gap-2 px-3 py-2 text-sm text-left
+                  transition-colors duration-150
+                  ${isSelected ? 'bg-lark-primary/10 text-lark-primary' : 'text-lark-text hover:bg-lark-background'}
+                `}
+              >
+                <span
+                  className={`
+                    w-4 h-4 border rounded flex items-center justify-center flex-shrink-0
+                    ${isSelected ? 'border-lark-primary bg-lark-primary' : 'border-gray-300'}
+                  `}
+                >
+                  {isSelected && (
+                    <svg
+                      className="w-3 h-3 text-white"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={3}
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  )}
+                </span>
+                <span>{option.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Single-select dropdown for assignee/meeting filters
+ */
+interface SingleSelectDropdownProps {
+  readonly label: string;
+  readonly options: readonly { readonly value: string; readonly label: string }[];
+  readonly selected: string | undefined;
+  readonly onChange: (value: string | undefined) => void;
+  readonly className?: string | undefined;
+}
+
+function SingleSelectDropdown({
+  label,
+  options,
+  selected,
+  onChange,
+  className = '',
+}: SingleSelectDropdownProps): JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent): void => {
+      if (
+        containerRef.current !== null &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return (): void => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const handleToggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  const handleOptionClick = useCallback(
+    (value: string | undefined) => {
+      onChange(value);
+      setIsOpen(false);
+    },
+    [onChange]
+  );
+
+  const displayText =
+    selected === undefined
+      ? label
+      : options.find((o) => o.value === selected)?.label ?? label;
+
+  return (
+    <div ref={containerRef} className={`relative ${className}`}>
+      <button
+        type="button"
+        onClick={handleToggle}
+        className={`
+          flex items-center justify-between gap-2 px-3 py-2 text-sm
+          border border-lark-border rounded-lg
+          bg-white text-lark-text
+          transition-colors duration-150
+          hover:border-lark-primary cursor-pointer
+          ${isOpen ? 'ring-2 ring-lark-primary border-transparent' : ''}
+          ${selected !== undefined ? 'bg-lark-primary/5' : ''}
+        `}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+      >
+        <span className={selected === undefined ? 'text-gray-500' : ''}>
+          {displayText}
+        </span>
+        <svg
+          className={`w-4 h-4 text-gray-400 transition-transform duration-150 ${
+            isOpen ? 'transform rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <ul
+          className="absolute z-50 mt-1 w-48 bg-white border border-lark-border rounded-lg shadow-lg py-1 max-h-60 overflow-auto"
+          role="listbox"
+        >
+          <li
+            role="option"
+            aria-selected={selected === undefined}
+            className={`
+              px-3 py-2 text-sm cursor-pointer
+              transition-colors duration-150
+              ${selected === undefined ? 'bg-lark-primary/10 text-lark-primary font-medium' : 'text-lark-text hover:bg-lark-background'}
+            `}
+            onClick={() => handleOptionClick(undefined)}
+          >
+            All
+          </li>
+          {options.map((option) => (
+            <li
+              key={option.value}
+              role="option"
+              aria-selected={option.value === selected}
+              className={`
+                px-3 py-2 text-sm cursor-pointer
+                transition-colors duration-150
+                ${option.value === selected ? 'bg-lark-primary/10 text-lark-primary font-medium' : 'text-lark-text hover:bg-lark-background'}
+              `}
+              onClick={() => handleOptionClick(option.value)}
+            >
+              {option.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/**
+ * ActionItemFilters component
+ *
+ * @description Filter panel for action items with multi-select status/priority,
+ * assignee dropdown, overdue checkbox, and clear button
+ * @example
+ * ```tsx
+ * <ActionItemFilters
+ *   filters={filters}
+ *   onChange={setFilters}
+ *   assignees={speakers}
+ *   meetings={meetingList}
+ * />
+ * ```
+ */
+function ActionItemFiltersInner({
+  filters,
+  onChange,
+  assignees = [],
+  meetings = [],
+  className = '',
+}: ActionItemFiltersProps): JSX.Element {
+  const statusOptions: readonly { readonly value: ActionItemStatus; readonly label: string }[] = [
+    { value: 'pending', label: STATUS_LABELS.pending },
+    { value: 'in_progress', label: STATUS_LABELS.in_progress },
+    { value: 'completed', label: STATUS_LABELS.completed },
+  ];
+
+  const priorityOptions: readonly { readonly value: Priority; readonly label: string }[] = [
+    { value: 'high', label: PRIORITY_LABELS.high },
+    { value: 'medium', label: PRIORITY_LABELS.medium },
+    { value: 'low', label: PRIORITY_LABELS.low },
+  ];
+
+  const assigneeOptions = assignees.map((a) => ({
+    value: a.id,
+    label: a.name,
+  }));
+
+  const meetingOptions = meetings.map((m) => ({
+    value: m.id,
+    label: m.title,
+  }));
+
+  const handleStatusChange = useCallback(
+    (statuses: readonly ActionItemStatus[]) => {
+      onChange({ ...filters, statuses });
+    },
+    [filters, onChange]
+  );
+
+  const handlePriorityChange = useCallback(
+    (priorities: readonly Priority[]) => {
+      onChange({ ...filters, priorities });
+    },
+    [filters, onChange]
+  );
+
+  const handleAssigneeChange = useCallback(
+    (assigneeId: string | undefined) => {
+      onChange({ ...filters, assigneeId });
+    },
+    [filters, onChange]
+  );
+
+  const handleMeetingChange = useCallback(
+    (meetingId: string | undefined) => {
+      onChange({ ...filters, meetingId });
+    },
+    [filters, onChange]
+  );
+
+  const handleOverdueChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChange({ ...filters, overdueOnly: event.target.checked });
+    },
+    [filters, onChange]
+  );
+
+  const handleClearFilters = useCallback(() => {
+    onChange(createDefaultFilters());
+  }, [onChange]);
+
+  const hasFilters = hasActiveFilters(filters);
+
+  return (
+    <div className={`flex flex-wrap items-center gap-3 ${className}`}>
+      {/* Status filter */}
+      <MultiSelectDropdown
+        label="Status"
+        options={statusOptions}
+        selected={filters.statuses}
+        onChange={handleStatusChange}
+      />
+
+      {/* Priority filter */}
+      <MultiSelectDropdown
+        label="Priority"
+        options={priorityOptions}
+        selected={filters.priorities}
+        onChange={handlePriorityChange}
+      />
+
+      {/* Assignee filter */}
+      {assignees.length > 0 && (
+        <SingleSelectDropdown
+          label="Assignee"
+          options={assigneeOptions}
+          selected={filters.assigneeId}
+          onChange={handleAssigneeChange}
+        />
+      )}
+
+      {/* Meeting filter */}
+      {meetings.length > 0 && (
+        <SingleSelectDropdown
+          label="Meeting"
+          options={meetingOptions}
+          selected={filters.meetingId}
+          onChange={handleMeetingChange}
+        />
+      )}
+
+      {/* Overdue only checkbox */}
+      <label className="flex items-center gap-2 text-sm text-lark-text cursor-pointer">
+        <input
+          type="checkbox"
+          checked={filters.overdueOnly}
+          onChange={handleOverdueChange}
+          className="w-4 h-4 rounded border-gray-300 text-lark-primary focus:ring-lark-primary"
+        />
+        <span>Overdue only</span>
+      </label>
+
+      {/* Clear filters button */}
+      {hasFilters && (
+        <button
+          type="button"
+          onClick={handleClearFilters}
+          className="
+            flex items-center gap-1 px-3 py-2 text-sm
+            text-gray-500 hover:text-lark-text
+            transition-colors duration-150
+          "
+          aria-label="Clear all filters"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+          <span>Clear</span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+export const ActionItemFiltersComponent = memo(ActionItemFiltersInner);
+
+// Named export for cleaner imports
+export { ActionItemFiltersComponent as ActionItemFilters };

--- a/src/components/action-items/ActionItemList.tsx
+++ b/src/components/action-items/ActionItemList.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+/**
+ * ActionItemList component
+ * @module components/action-items/ActionItemList
+ */
+
+import { ActionItemCard } from './ActionItemCard';
+import { ActionItemEmptyState } from './ActionItemEmptyState';
+import { ActionItemListSkeleton } from './ActionItemSkeleton';
+import type { ActionItemListProps } from './types';
+
+/**
+ * ActionItemList component
+ *
+ * @description Displays a list of action items with loading and empty states
+ * @example
+ * ```tsx
+ * <ActionItemList
+ *   items={actionItems}
+ *   isLoading={isLoading}
+ *   onStatusChange={(id, status) => updateStatus(id, status)}
+ *   onItemClick={(item) => openDetails(item)}
+ *   emptyMessage="タスクが見つかりません"
+ * />
+ * ```
+ */
+export function ActionItemList({
+  items,
+  isLoading = false,
+  onStatusChange,
+  onItemClick,
+  emptyMessage,
+  className = '',
+}: ActionItemListProps): JSX.Element {
+  // Show loading skeleton
+  if (isLoading) {
+    return <ActionItemListSkeleton count={3} className={className} />;
+  }
+
+  // Show empty state
+  if (items.length === 0) {
+    return <ActionItemEmptyState message={emptyMessage} className={className} />;
+  }
+
+  return (
+    <div
+      className={`space-y-4 ${className}`}
+      role="list"
+      aria-label="アクションアイテム一覧"
+    >
+      {items.map((item) => (
+        <div key={item.id} role="listitem">
+          <ActionItemCard
+            item={item}
+            onStatusChange={onStatusChange}
+            onClick={onItemClick}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/action-items/ActionItemSearch.tsx
+++ b/src/components/action-items/ActionItemSearch.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { memo, useState, useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Props for ActionItemSearch component
+ */
+export interface ActionItemSearchProps {
+  /** Current search value */
+  readonly value: string;
+  /** Callback when search value changes (debounced) */
+  readonly onChange: (value: string) => void;
+  /** Placeholder text */
+  readonly placeholder?: string | undefined;
+  /** Debounce delay in milliseconds */
+  readonly debounceMs?: number | undefined;
+  /** Disabled state */
+  readonly disabled?: boolean | undefined;
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+/**
+ * ActionItemSearch component
+ *
+ * @description Search input with debounce for action item filtering
+ * @example
+ * ```tsx
+ * <ActionItemSearch
+ *   value={searchQuery}
+ *   onChange={setSearchQuery}
+ *   placeholder="Search action items..."
+ * />
+ * ```
+ */
+function ActionItemSearchInner({
+  value,
+  onChange,
+  placeholder = 'Search action items...',
+  debounceMs = 300,
+  disabled = false,
+  className = '',
+}: ActionItemSearchProps): JSX.Element {
+  const [internalValue, setInternalValue] = useState(value);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync internal value with external value
+  useEffect(() => {
+    setInternalValue(value);
+  }, [value]);
+
+  // Debounced onChange
+  const debouncedOnChange = useCallback(
+    (newValue: string) => {
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+      }
+
+      debounceTimerRef.current = setTimeout(() => {
+        onChange(newValue);
+      }, debounceMs);
+    },
+    [onChange, debounceMs]
+  );
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return (): void => {
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = event.target.value;
+      setInternalValue(newValue);
+      debouncedOnChange(newValue);
+    },
+    [debouncedOnChange]
+  );
+
+  const handleClear = useCallback(() => {
+    setInternalValue('');
+    onChange('');
+    if (debounceTimerRef.current !== null) {
+      clearTimeout(debounceTimerRef.current);
+    }
+  }, [onChange]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Escape') {
+        handleClear();
+      }
+    },
+    [handleClear]
+  );
+
+  return (
+    <div className={`relative ${className}`}>
+      {/* Search icon */}
+      <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+        <svg
+          className="w-5 h-5 text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+      </div>
+
+      {/* Input field */}
+      <input
+        type="text"
+        value={internalValue}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        className={`
+          w-full pl-10 pr-10 py-2 text-sm
+          border border-lark-border rounded-lg
+          bg-white text-lark-text
+          placeholder-gray-400
+          transition-colors duration-150
+          focus:outline-none focus:ring-2 focus:ring-lark-primary focus:border-transparent
+          disabled:bg-gray-100 disabled:cursor-not-allowed
+        `}
+        aria-label={placeholder}
+      />
+
+      {/* Clear button */}
+      {internalValue.length > 0 && !disabled && (
+        <button
+          type="button"
+          onClick={handleClear}
+          className="
+            absolute inset-y-0 right-0 flex items-center pr-3
+            text-gray-400 hover:text-gray-600
+            transition-colors duration-150
+          "
+          aria-label="Clear search"
+        >
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}
+
+export const ActionItemSearch = memo(ActionItemSearchInner);

--- a/src/components/action-items/ActionItemSkeleton.tsx
+++ b/src/components/action-items/ActionItemSkeleton.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+/**
+ * ActionItemSkeleton component
+ * @module components/action-items/ActionItemSkeleton
+ */
+
+import { Skeleton } from '@/components/ui/skeleton';
+import type { ActionItemSkeletonProps, ActionItemListSkeletonProps } from './types';
+
+/**
+ * ActionItemSkeleton component
+ *
+ * @description Skeleton loading placeholder for a single action item card
+ * @example
+ * ```tsx
+ * <ActionItemSkeleton />
+ * ```
+ */
+export function ActionItemSkeleton({
+  className = '',
+}: ActionItemSkeletonProps): JSX.Element {
+  return (
+    <div
+      className={`
+        border border-gray-200 rounded-lg bg-white p-4
+        ${className}
+      `}
+      aria-hidden="true"
+    >
+      {/* Header Row: Title and Due Date */}
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="flex-1">
+          {/* Title skeleton */}
+          <Skeleton className="h-4 w-3/4 mb-1" />
+          <Skeleton className="h-4 w-1/2" />
+        </div>
+        {/* Due date skeleton */}
+        <div className="flex-shrink-0">
+          <Skeleton className="h-3 w-16 mb-1" />
+          <Skeleton className="h-3 w-12" />
+        </div>
+      </div>
+
+      {/* Meta Row: Assignee, Priority, Meeting */}
+      <div className="flex items-center flex-wrap gap-2 mb-3">
+        {/* Assignee skeleton */}
+        <div className="flex items-center gap-1.5">
+          <Skeleton className="h-3 w-6" />
+          <Skeleton className="h-6 w-6 rounded-full" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+
+        {/* Priority badge skeleton */}
+        <div className="flex items-center gap-1.5">
+          <Skeleton className="h-3 w-10" />
+          <Skeleton className="h-5 w-8 rounded-full" />
+        </div>
+
+        {/* Status badge skeleton */}
+        <Skeleton className="h-5 w-12 rounded-full" />
+
+        {/* Meeting skeleton */}
+        <div className="flex items-center gap-1.5">
+          <Skeleton className="h-3 w-6" />
+          <Skeleton className="h-3 w-20" />
+        </div>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-7 w-20 rounded-md" />
+        <Skeleton className="h-7 w-14 rounded-md" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * ActionItemListSkeleton component
+ *
+ * @description Skeleton loading placeholder for a list of action items
+ * @example
+ * ```tsx
+ * <ActionItemListSkeleton count={5} />
+ * ```
+ */
+export function ActionItemListSkeleton({
+  count = 3,
+  className = '',
+}: ActionItemListSkeletonProps): JSX.Element {
+  return (
+    <div
+      className={`space-y-4 ${className}`}
+      role="status"
+      aria-label="読み込み中"
+    >
+      {Array.from({ length: count }, (_, index) => (
+        <ActionItemSkeleton key={index} />
+      ))}
+      <span className="sr-only">読み込み中...</span>
+    </div>
+  );
+}

--- a/src/components/action-items/ActionItemSort.tsx
+++ b/src/components/action-items/ActionItemSort.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { memo, useCallback, useState, useRef, useEffect } from 'react';
+import type {
+  ActionItemSortOptions,
+  ActionItemSortField,
+  SortDirection,
+} from './types';
+import { SORT_FIELD_LABELS } from './types';
+
+/**
+ * Props for ActionItemSort component
+ */
+export interface ActionItemSortProps {
+  /** Current sort options */
+  readonly sortOptions: ActionItemSortOptions;
+  /** Callback when sort options change */
+  readonly onChange: (options: ActionItemSortOptions) => void;
+  /** Disabled state */
+  readonly disabled?: boolean | undefined;
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Sort option with direction
+ */
+interface SortOptionItem {
+  readonly field: ActionItemSortField;
+  readonly direction: SortDirection;
+  readonly label: string;
+}
+
+/**
+ * Available sort options
+ */
+const SORT_OPTIONS: readonly SortOptionItem[] = [
+  { field: 'dueDate', direction: 'asc', label: 'Due Date (Earliest)' },
+  { field: 'dueDate', direction: 'desc', label: 'Due Date (Latest)' },
+  { field: 'priority', direction: 'asc', label: 'Priority (High to Low)' },
+  { field: 'priority', direction: 'desc', label: 'Priority (Low to High)' },
+  { field: 'createdAt', direction: 'desc', label: 'Created (Newest)' },
+  { field: 'createdAt', direction: 'asc', label: 'Created (Oldest)' },
+  { field: 'meetingDate', direction: 'desc', label: 'Meeting Date (Recent)' },
+  { field: 'meetingDate', direction: 'asc', label: 'Meeting Date (Oldest)' },
+];
+
+/**
+ * Get current sort option key
+ */
+function getSortKey(options: ActionItemSortOptions): string {
+  return `${options.field}-${options.direction}`;
+}
+
+/**
+ * Get current sort label
+ */
+function getCurrentSortLabel(options: ActionItemSortOptions): string {
+  const option = SORT_OPTIONS.find(
+    (o) => o.field === options.field && o.direction === options.direction
+  );
+  return option?.label ?? SORT_FIELD_LABELS[options.field];
+}
+
+/**
+ * ActionItemSort component
+ *
+ * @description Sort dropdown for action items with field and direction options
+ * @example
+ * ```tsx
+ * <ActionItemSort
+ *   sortOptions={sortOptions}
+ *   onChange={setSortOptions}
+ * />
+ * ```
+ */
+function ActionItemSortInner({
+  sortOptions,
+  onChange,
+  disabled = false,
+  className = '',
+}: ActionItemSortProps): JSX.Element {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent): void => {
+      if (
+        containerRef.current !== null &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return (): void => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const handleToggle = useCallback(() => {
+    if (!disabled) {
+      setIsOpen((prev) => !prev);
+    }
+  }, [disabled]);
+
+  const handleOptionSelect = useCallback(
+    (field: ActionItemSortField, direction: SortDirection) => {
+      onChange({ field, direction });
+      setIsOpen(false);
+    },
+    [onChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        handleToggle();
+      } else if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    },
+    [handleToggle]
+  );
+
+  const currentKey = getSortKey(sortOptions);
+  const currentLabel = getCurrentSortLabel(sortOptions);
+
+  return (
+    <div ref={containerRef} className={`relative ${className}`}>
+      {/* Trigger button */}
+      <button
+        type="button"
+        onClick={handleToggle}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+        className={`
+          flex items-center justify-between gap-2 px-3 py-2 text-sm
+          border border-lark-border rounded-lg
+          bg-white text-lark-text
+          transition-colors duration-150
+          ${disabled ? 'bg-gray-100 cursor-not-allowed text-gray-400' : 'hover:border-lark-primary cursor-pointer'}
+          ${isOpen ? 'ring-2 ring-lark-primary border-transparent' : ''}
+        `}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+      >
+        {/* Sort icon */}
+        <svg
+          className="w-4 h-4 text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 4h13M3 8h9m-9 4h6m4 0l4-4m0 0l4 4m-4-4v12"
+          />
+        </svg>
+        <span>{currentLabel}</span>
+        <svg
+          className={`w-4 h-4 text-gray-400 transition-transform duration-150 ${
+            isOpen ? 'transform rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </button>
+
+      {/* Dropdown menu */}
+      {isOpen && (
+        <ul
+          className="absolute z-50 mt-1 w-56 bg-white border border-lark-border rounded-lg shadow-lg py-1 max-h-72 overflow-auto"
+          role="listbox"
+          aria-activedescendant={`sort-option-${currentKey}`}
+        >
+          {SORT_OPTIONS.map((option) => {
+            const key = `${option.field}-${option.direction}`;
+            const isSelected = key === currentKey;
+
+            return (
+              <li
+                key={key}
+                id={`sort-option-${key}`}
+                role="option"
+                aria-selected={isSelected}
+                className={`
+                  px-3 py-2 text-sm cursor-pointer
+                  transition-colors duration-150
+                  ${isSelected ? 'bg-lark-primary/10 text-lark-primary font-medium' : 'text-lark-text hover:bg-lark-background'}
+                `}
+                onClick={() => handleOptionSelect(option.field, option.direction)}
+              >
+                <div className="flex items-center justify-between">
+                  <span>{option.label}</span>
+                  {isSelected && (
+                    <svg
+                      className="w-4 h-4 text-lark-primary"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export const ActionItemSort = memo(ActionItemSortInner);

--- a/src/components/action-items/ActionItemStats.tsx
+++ b/src/components/action-items/ActionItemStats.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+/**
+ * ActionItemStats component
+ * @module components/action-items/ActionItemStats
+ */
+
+import { useCallback } from 'react';
+import type { ActionItemStatsProps, ActionItemStatus } from './types';
+
+/**
+ * Stat card configuration
+ */
+interface StatCardConfig {
+  key: 'all' | ActionItemStatus | 'overdue';
+  label: string;
+  getValue: (stats: ActionItemStatsProps['stats']) => number;
+  bgColor: string;
+  textColor: string;
+  iconColor: string;
+  icon: JSX.Element;
+}
+
+/**
+ * Get stat card configurations
+ */
+function getStatCards(): readonly StatCardConfig[] {
+  return [
+    {
+      key: 'all',
+      label: '全体',
+      getValue: (stats) => stats.total,
+      bgColor: 'bg-gray-50 hover:bg-gray-100',
+      textColor: 'text-gray-900',
+      iconColor: 'text-gray-500',
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="w-5 h-5"
+        >
+          <path
+            fillRule="evenodd"
+            d="M6 4.75A.75.75 0 016.75 4h10.5a.75.75 0 010 1.5H6.75A.75.75 0 016 4.75zM6 10a.75.75 0 01.75-.75h10.5a.75.75 0 010 1.5H6.75A.75.75 0 016 10zm0 5.25a.75.75 0 01.75-.75h10.5a.75.75 0 010 1.5H6.75a.75.75 0 01-.75-.75zM1.99 4.75a1 1 0 011-1H3a1 1 0 011 1v.01a1 1 0 01-1 1h-.01a1 1 0 01-1-1v-.01zM1.99 15.25a1 1 0 011-1H3a1 1 0 011 1v.01a1 1 0 01-1 1h-.01a1 1 0 01-1-1v-.01zM1.99 10a1 1 0 011-1H3a1 1 0 011 1v.01a1 1 0 01-1 1h-.01a1 1 0 01-1-1V10z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ),
+    },
+    {
+      key: 'pending',
+      label: '未着手',
+      getValue: (stats) => stats.pending,
+      bgColor: 'bg-gray-50 hover:bg-gray-100',
+      textColor: 'text-gray-700',
+      iconColor: 'text-gray-400',
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="w-5 h-5"
+        >
+          <path
+            fillRule="evenodd"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-13a.75.75 0 00-1.5 0v5c0 .414.336.75.75.75h4a.75.75 0 000-1.5h-3.25V5z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ),
+    },
+    {
+      key: 'in_progress',
+      label: '進行中',
+      getValue: (stats) => stats.inProgress,
+      bgColor: 'bg-blue-50 hover:bg-blue-100',
+      textColor: 'text-blue-700',
+      iconColor: 'text-blue-500',
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="w-5 h-5"
+        >
+          <path
+            fillRule="evenodd"
+            d="M15.312 11.424a5.5 5.5 0 01-9.201 2.466l-.312-.311h2.433a.75.75 0 000-1.5H3.989a.75.75 0 00-.75.75v4.242a.75.75 0 001.5 0v-2.43l.31.31a7 7 0 0011.712-3.138.75.75 0 00-1.449-.39zm1.23-3.723a.75.75 0 00.219-.53V2.929a.75.75 0 00-1.5 0V5.36l-.31-.31A7 7 0 003.239 8.188a.75.75 0 101.448.389A5.5 5.5 0 0113.89 6.11l.311.31h-2.432a.75.75 0 000 1.5h4.242a.75.75 0 00.53-.219z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ),
+    },
+    {
+      key: 'completed',
+      label: '完了',
+      getValue: (stats) => stats.completed,
+      bgColor: 'bg-green-50 hover:bg-green-100',
+      textColor: 'text-green-700',
+      iconColor: 'text-green-500',
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="w-5 h-5"
+        >
+          <path
+            fillRule="evenodd"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ),
+    },
+    {
+      key: 'overdue',
+      label: '期限切れ',
+      getValue: (stats) => stats.overdue,
+      bgColor: 'bg-red-50 hover:bg-red-100',
+      textColor: 'text-red-700',
+      iconColor: 'text-red-500',
+      icon: (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className="w-5 h-5"
+        >
+          <path
+            fillRule="evenodd"
+            d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+            clipRule="evenodd"
+          />
+        </svg>
+      ),
+    },
+  ] as const;
+}
+
+/**
+ * ActionItemStats component
+ *
+ * @description Displays statistics summary cards for action items
+ * @example
+ * ```tsx
+ * <ActionItemStats
+ *   stats={{ total: 10, pending: 3, inProgress: 4, completed: 2, overdue: 1 }}
+ *   onFilterChange={(filter) => setFilter(filter)}
+ *   activeFilter="all"
+ * />
+ * ```
+ */
+export function ActionItemStats({
+  stats,
+  onFilterChange,
+  activeFilter,
+  className = '',
+}: ActionItemStatsProps): JSX.Element {
+  const statCards = getStatCards();
+
+  const handleCardClick = useCallback(
+    (key: 'all' | ActionItemStatus | 'overdue') => {
+      onFilterChange?.(key);
+    },
+    [onFilterChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, key: 'all' | ActionItemStatus | 'overdue') => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onFilterChange?.(key);
+      }
+    },
+    [onFilterChange]
+  );
+
+  return (
+    <div
+      className={`grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3 ${className}`}
+      role="group"
+      aria-label="アクションアイテム統計"
+    >
+      {statCards.map((card) => {
+        const value = card.getValue(stats);
+        const isActive = activeFilter === card.key;
+        const isClickable = onFilterChange !== undefined;
+
+        return (
+          <div
+            key={card.key}
+            className={`
+              rounded-lg p-4 transition-all
+              ${card.bgColor}
+              ${isClickable ? 'cursor-pointer' : ''}
+              ${isActive ? 'ring-2 ring-blue-500 ring-offset-1' : ''}
+            `}
+            onClick={isClickable ? (): void => handleCardClick(card.key) : undefined}
+            onKeyDown={isClickable ? (e: React.KeyboardEvent): void => handleKeyDown(e, card.key) : undefined}
+            role={isClickable ? 'button' : undefined}
+            tabIndex={isClickable ? 0 : undefined}
+            aria-pressed={isClickable ? isActive : undefined}
+            aria-label={`${card.label}: ${value}件`}
+          >
+            <div className="flex items-center justify-between mb-2">
+              <span className={`text-xs font-medium ${card.textColor}`}>
+                {card.label}
+              </span>
+              <span className={card.iconColor}>{card.icon}</span>
+            </div>
+            <div className={`text-2xl font-bold ${card.textColor}`}>
+              {value}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/action-items/ActionItemToolbar.tsx
+++ b/src/components/action-items/ActionItemToolbar.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { memo } from 'react';
+import type { Speaker } from '@/types/minutes';
+import type {
+  ActionItemFilters as FilterState,
+  ActionItemSortOptions,
+  MeetingReference,
+} from './types';
+import { ActionItemFilters } from './ActionItemFilters';
+import { ActionItemSearch } from './ActionItemSearch';
+import { ActionItemSort } from './ActionItemSort';
+
+/**
+ * Props for ActionItemToolbar component
+ */
+export interface ActionItemToolbarProps {
+  /** Current filter state */
+  readonly filters: FilterState;
+  /** Current sort options */
+  readonly sortOptions: ActionItemSortOptions;
+  /** Current search query */
+  readonly searchQuery: string;
+  /** Callback when filters change */
+  readonly onFiltersChange: (filters: FilterState) => void;
+  /** Callback when sort options change */
+  readonly onSortChange: (options: ActionItemSortOptions) => void;
+  /** Callback when search query changes */
+  readonly onSearchChange: (query: string) => void;
+  /** Available assignees for filter dropdown */
+  readonly assignees?: readonly Speaker[] | undefined;
+  /** Available meetings for filter dropdown */
+  readonly meetings?: readonly MeetingReference[] | undefined;
+  /** Hide search input */
+  readonly hideSearch?: boolean | undefined;
+  /** Hide filters */
+  readonly hideFilters?: boolean | undefined;
+  /** Hide sort */
+  readonly hideSort?: boolean | undefined;
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+/**
+ * ActionItemToolbar component
+ *
+ * @description Combined toolbar with filters, sort, and search for action items
+ *
+ * Layout:
+ * ```
+ * ┌────────────────────────────────────────────────────────────────┐
+ * │ [Assignee ▼] [Status ▼] [Priority ▼] [Sort ▼]  [🔍 Search...] │
+ * └────────────────────────────────────────────────────────────────┘
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <ActionItemToolbar
+ *   filters={filters}
+ *   sortOptions={sortOptions}
+ *   searchQuery={searchQuery}
+ *   onFiltersChange={setFilters}
+ *   onSortChange={setSortOptions}
+ *   onSearchChange={setSearchQuery}
+ *   assignees={speakers}
+ *   meetings={meetingList}
+ * />
+ * ```
+ */
+function ActionItemToolbarInner({
+  filters,
+  sortOptions,
+  searchQuery,
+  onFiltersChange,
+  onSortChange,
+  onSearchChange,
+  assignees = [],
+  meetings = [],
+  hideSearch = false,
+  hideFilters = false,
+  hideSort = false,
+  className = '',
+}: ActionItemToolbarProps): JSX.Element {
+  return (
+    <div
+      className={`
+        flex flex-col gap-4 p-4
+        bg-white border border-lark-border rounded-lg
+        ${className}
+      `}
+    >
+      {/* Main toolbar row */}
+      <div className="flex flex-wrap items-center gap-4">
+        {/* Filters section */}
+        {!hideFilters && (
+          <ActionItemFilters
+            filters={filters}
+            onChange={onFiltersChange}
+            assignees={assignees}
+            meetings={meetings}
+            className="flex-1 min-w-0"
+          />
+        )}
+
+        {/* Sort and Search section */}
+        <div className="flex items-center gap-3 flex-shrink-0">
+          {/* Sort dropdown */}
+          {!hideSort && (
+            <ActionItemSort
+              sortOptions={sortOptions}
+              onChange={onSortChange}
+            />
+          )}
+
+          {/* Search input */}
+          {!hideSearch && (
+            <ActionItemSearch
+              value={searchQuery}
+              onChange={onSearchChange}
+              className="w-64"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const ActionItemToolbar = memo(ActionItemToolbarInner);
+
+/**
+ * Compact toolbar variant
+ *
+ * @description Minimal toolbar with just search and sort
+ */
+export interface ActionItemCompactToolbarProps {
+  /** Current sort options */
+  readonly sortOptions: ActionItemSortOptions;
+  /** Current search query */
+  readonly searchQuery: string;
+  /** Callback when sort options change */
+  readonly onSortChange: (options: ActionItemSortOptions) => void;
+  /** Callback when search query changes */
+  readonly onSearchChange: (query: string) => void;
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+function ActionItemCompactToolbarInner({
+  sortOptions,
+  searchQuery,
+  onSortChange,
+  onSearchChange,
+  className = '',
+}: ActionItemCompactToolbarProps): JSX.Element {
+  return (
+    <div className={`flex items-center gap-3 ${className}`}>
+      <ActionItemSort
+        sortOptions={sortOptions}
+        onChange={onSortChange}
+      />
+      <ActionItemSearch
+        value={searchQuery}
+        onChange={onSearchChange}
+        className="flex-1"
+      />
+    </div>
+  );
+}
+
+export const ActionItemCompactToolbar = memo(ActionItemCompactToolbarInner);

--- a/src/components/action-items/index.ts
+++ b/src/components/action-items/index.ts
@@ -1,0 +1,68 @@
+/**
+ * Action Items Components
+ *
+ * @description Components for displaying and managing action items
+ * @module components/action-items
+ */
+
+// Types
+export type {
+  MeetingReference,
+  ManagedActionItem,
+  ActionItemStats as ActionItemStatsData,
+  ActionItemCardProps,
+  ActionItemListProps,
+  ActionItemStatsProps,
+  ActionItemEmptyStateProps,
+  ActionItemSkeletonProps,
+  ActionItemListSkeletonProps,
+  ActionItemSortField,
+  SortDirection,
+  ActionItemSortOptions,
+  ActionItemFilters,
+  ActionItemStatus,
+  Priority,
+} from './types';
+
+export {
+  createDefaultFilters,
+  createDefaultSortOptions,
+  hasActiveFilters,
+  STATUS_LABELS,
+  PRIORITY_LABELS,
+  SORT_FIELD_LABELS,
+} from './types';
+
+// ActionItemCard
+export { ActionItemCard } from './ActionItemCard';
+
+// ActionItemFilters
+export { ActionItemFilters as ActionItemFiltersComponent } from './ActionItemFilters';
+export type { ActionItemFiltersProps } from './ActionItemFilters';
+
+// ActionItemSearch
+export { ActionItemSearch } from './ActionItemSearch';
+export type { ActionItemSearchProps } from './ActionItemSearch';
+
+// ActionItemSort
+export { ActionItemSort } from './ActionItemSort';
+export type { ActionItemSortProps } from './ActionItemSort';
+
+// ActionItemToolbar
+export { ActionItemToolbar, ActionItemCompactToolbar } from './ActionItemToolbar';
+export type {
+  ActionItemToolbarProps,
+  ActionItemCompactToolbarProps,
+} from './ActionItemToolbar';
+
+// ActionItemEmptyState
+export { ActionItemEmptyState } from './ActionItemEmptyState';
+
+// ActionItemSkeleton
+export { ActionItemSkeleton, ActionItemListSkeleton } from './ActionItemSkeleton';
+
+// ActionItemStats
+export { ActionItemStats } from './ActionItemStats';
+
+// ActionItemList
+export { ActionItemList } from './ActionItemList';

--- a/src/components/action-items/types.ts
+++ b/src/components/action-items/types.ts
@@ -1,0 +1,239 @@
+/**
+ * Action Items component type definitions
+ * @module components/action-items/types
+ */
+
+import type { ActionItem, ActionItemStatus, Priority } from '@/types';
+
+/**
+ * Meeting reference for action items
+ */
+export interface MeetingReference {
+  /** Meeting ID */
+  readonly id: string;
+  /** Meeting title */
+  readonly title: string;
+}
+
+/**
+ * Extended ActionItem with management metadata
+ * Used in action item lists and management views
+ */
+export interface ManagedActionItem extends ActionItem {
+  /** Source meeting information */
+  readonly meeting?: MeetingReference | undefined;
+  /** Created timestamp in ISO format */
+  readonly createdAt?: string | undefined;
+  /** Last updated timestamp in ISO format */
+  readonly updatedAt?: string | undefined;
+}
+
+/**
+ * Action item statistics
+ */
+export interface ActionItemStats {
+  /** Total number of action items */
+  readonly total: number;
+  /** Number of pending items */
+  readonly pending: number;
+  /** Number of in-progress items */
+  readonly inProgress: number;
+  /** Number of completed items */
+  readonly completed: number;
+  /** Number of overdue items */
+  readonly overdue: number;
+}
+
+/**
+ * Props for ActionItemCard component
+ */
+export interface ActionItemCardProps {
+  /** The action item to display */
+  readonly item: ManagedActionItem;
+  /** Callback when status changes */
+  readonly onStatusChange: (id: string, status: ActionItemStatus) => void;
+  /** Callback when edit is clicked */
+  readonly onEdit?: ((item: ManagedActionItem) => void) | undefined;
+  /** Callback when card is clicked */
+  readonly onClick?: ((item: ManagedActionItem) => void) | undefined;
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Props for ActionItemList component
+ */
+export interface ActionItemListProps {
+  /** Array of action items to display */
+  readonly items: readonly ManagedActionItem[];
+  /** Whether data is loading */
+  readonly isLoading?: boolean | undefined;
+  /** Callback when item status changes */
+  readonly onStatusChange: (id: string, status: ActionItemStatus) => void;
+  /** Callback when item is clicked */
+  readonly onItemClick?: ((item: ManagedActionItem) => void) | undefined;
+  /** Message to show when list is empty */
+  readonly emptyMessage?: string | undefined;
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Props for ActionItemStats component
+ */
+export interface ActionItemStatsProps {
+  /** Statistics data */
+  readonly stats: ActionItemStats;
+  /** Callback when a stat card is clicked for filtering */
+  readonly onFilterChange?: ((filter: ActionItemStatus | 'overdue' | 'all') => void) | undefined;
+  /** Currently active filter */
+  readonly activeFilter?: ActionItemStatus | 'overdue' | 'all' | undefined;
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Props for ActionItemEmptyState component
+ */
+export interface ActionItemEmptyStateProps {
+  /** Custom message to display */
+  readonly message?: string | undefined;
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Props for ActionItemSkeleton component
+ */
+export interface ActionItemSkeletonProps {
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+/**
+ * Props for ActionItemListSkeleton component
+ */
+export interface ActionItemListSkeletonProps {
+  /** Number of skeleton cards to show */
+  readonly count?: number | undefined;
+  /** Additional CSS classes */
+  readonly className?: string | undefined;
+}
+
+// ============================================================================
+// Filter & Sort Types
+// ============================================================================
+
+/**
+ * Sort field options for action items
+ */
+export type ActionItemSortField =
+  | 'dueDate'
+  | 'priority'
+  | 'createdAt'
+  | 'meetingDate';
+
+/**
+ * Sort direction
+ */
+export type SortDirection = 'asc' | 'desc';
+
+/**
+ * Sort options for action items
+ */
+export interface ActionItemSortOptions {
+  /** Field to sort by */
+  readonly field: ActionItemSortField;
+  /** Sort direction */
+  readonly direction: SortDirection;
+}
+
+/**
+ * Filter options for action items (supports multi-select)
+ */
+export interface ActionItemFilters {
+  /** Selected statuses (empty = all) */
+  readonly statuses: readonly ActionItemStatus[];
+  /** Selected priorities (empty = all) */
+  readonly priorities: readonly Priority[];
+  /** Selected assignee ID (undefined = all) */
+  readonly assigneeId?: string | undefined;
+  /** Selected meeting ID (undefined = all) */
+  readonly meetingId?: string | undefined;
+  /** Show only overdue items */
+  readonly overdueOnly: boolean;
+  /** Due date range filter */
+  readonly dueDateRange?: {
+    readonly start: string | undefined;
+    readonly end: string | undefined;
+  } | undefined;
+}
+
+/**
+ * Create default filter options
+ */
+export function createDefaultFilters(): ActionItemFilters {
+  return {
+    statuses: [],
+    priorities: [],
+    assigneeId: undefined,
+    meetingId: undefined,
+    overdueOnly: false,
+    dueDateRange: undefined,
+  };
+}
+
+/**
+ * Create default sort options
+ */
+export function createDefaultSortOptions(): ActionItemSortOptions {
+  return {
+    field: 'dueDate',
+    direction: 'asc',
+  };
+}
+
+/**
+ * Check if any filters are active
+ */
+export function hasActiveFilters(filters: ActionItemFilters): boolean {
+  return (
+    filters.statuses.length > 0 ||
+    filters.priorities.length > 0 ||
+    filters.assigneeId !== undefined ||
+    filters.meetingId !== undefined ||
+    filters.overdueOnly ||
+    filters.dueDateRange !== undefined
+  );
+}
+
+/**
+ * Status display labels
+ */
+export const STATUS_LABELS: Record<ActionItemStatus, string> = {
+  pending: 'Pending',
+  in_progress: 'In Progress',
+  completed: 'Completed',
+};
+
+/**
+ * Priority display labels
+ */
+export const PRIORITY_LABELS: Record<Priority, string> = {
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+};
+
+/**
+ * Sort field display labels
+ */
+export const SORT_FIELD_LABELS: Record<ActionItemSortField, string> = {
+  dueDate: 'Due Date',
+  priority: 'Priority',
+  createdAt: 'Created At',
+  meetingDate: 'Meeting Date',
+};
+
+// Re-export types from base for convenience
+export type { ActionItemStatus, Priority };

--- a/src/components/minutes/MinutesViewer.tsx
+++ b/src/components/minutes/MinutesViewer.tsx
@@ -40,6 +40,8 @@ export interface MinutesViewerProps {
   readonly onTopicClick?: ((topic: TopicSegment) => void) | undefined;
   /** Callback when action item status changes */
   readonly onActionStatusChange?: ((id: string, status: ActionItemStatus) => void) | undefined;
+  /** Whether to sync action item status changes with API */
+  readonly enableApiSync?: boolean | undefined;
   /** Initial active tab */
   readonly initialTab?: MinutesTab | undefined;
   /** Custom class name */
@@ -126,6 +128,7 @@ function MinutesViewerInner({
   onRegenerate,
   onTopicClick,
   onActionStatusChange,
+  enableApiSync = false,
   initialTab = 'topics',
   className = '',
 }: MinutesViewerProps): JSX.Element {
@@ -376,11 +379,41 @@ function MinutesViewerInner({
         )}
 
         {activeTab === 'actions' && (
-          <ActionItemList
-            actionItems={minutes.actionItems}
-            showFilters={true}
-            onStatusChange={onActionStatusChange}
-          />
+          <>
+            <ActionItemList
+              actionItems={minutes.actionItems}
+              showFilters={true}
+              onStatusChange={onActionStatusChange}
+              enableApiSync={enableApiSync}
+            />
+            {/* Link to all action items page */}
+            <div className="mt-4 pt-4 border-t border-lark-border">
+              <a
+                href="/action-items"
+                className="
+                  inline-flex items-center gap-2
+                  text-sm text-lark-primary hover:text-lark-primary-dark
+                  transition-colors
+                "
+              >
+                View all action items
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17 8l4 4m0 0l-4 4m4-4H3"
+                  />
+                </svg>
+              </a>
+            </div>
+          </>
         )}
       </div>
 

--- a/src/services/__tests__/action-item.service.test.ts
+++ b/src/services/__tests__/action-item.service.test.ts
@@ -1,0 +1,894 @@
+/**
+ * ActionItemService unit tests
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ActionItemService,
+  ActionItemServiceError,
+  ActionItemNotFoundError,
+  ActionItemStore,
+  createActionItemService,
+  createTestActionItemService,
+} from '../action-item.service';
+import type { ManagedActionItem, ActionItemFilters } from '@/types/action-item';
+import type { Minutes } from '@/types/minutes';
+import { createEmptyMinutes, createActionItem, createSpeaker } from '@/types/minutes';
+
+// =============================================================================
+// Mock Data Factories
+// =============================================================================
+
+const createMockManagedActionItem = (
+  overrides: Partial<ManagedActionItem> = {}
+): ManagedActionItem => {
+  const now = new Date().toISOString();
+  return {
+    id: `action_test_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+    content: 'Test action item content',
+    priority: 'medium',
+    status: 'pending',
+    meetingId: 'meeting_001',
+    meetingTitle: 'Weekly Team Sync',
+    meetingDate: '2024-01-15',
+    extractedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    isOverdue: false,
+    ...overrides,
+  };
+};
+
+const createMockMinutes = (actionItemCount: number = 2): Minutes => {
+  const minutes = createEmptyMinutes('meeting_001', 'Weekly Team Sync');
+
+  for (let i = 0; i < actionItemCount; i++) {
+    const item = createActionItem(
+      `Action item ${i + 1}`,
+      i === 0 ? 'high' : 'medium',
+      createSpeaker(`user_${i}`, `User ${i}`),
+      `2024-02-${String(i + 15).padStart(2, '0')}`
+    );
+    minutes.actionItems.push(item);
+  }
+
+  return minutes;
+};
+
+// =============================================================================
+// ActionItemStore Tests
+// =============================================================================
+
+describe('ActionItemStore', () => {
+  let store: ActionItemStore;
+
+  beforeEach(() => {
+    // Create fresh store for each test
+    const result = createTestActionItemService();
+    store = result.store;
+  });
+
+  describe('add and get', () => {
+    it('should add and retrieve an item', () => {
+      const item = createMockManagedActionItem({ id: 'test_id_001' });
+      store.add(item);
+
+      const retrieved = store.get('test_id_001');
+      expect(retrieved).toEqual(item);
+    });
+
+    it('should return undefined for non-existent item', () => {
+      const retrieved = store.get('non_existent');
+      expect(retrieved).toBeUndefined();
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return empty array when no items', () => {
+      expect(store.getAll()).toEqual([]);
+    });
+
+    it('should return all items', () => {
+      const item1 = createMockManagedActionItem({ id: 'item_1' });
+      const item2 = createMockManagedActionItem({ id: 'item_2' });
+
+      store.add(item1);
+      store.add(item2);
+
+      const all = store.getAll();
+      expect(all).toHaveLength(2);
+      expect(all.map(i => i.id)).toContain('item_1');
+      expect(all.map(i => i.id)).toContain('item_2');
+    });
+  });
+
+  describe('update', () => {
+    it('should update an existing item', () => {
+      const item = createMockManagedActionItem({ id: 'update_test', status: 'pending' });
+      store.add(item);
+
+      const updated = store.update('update_test', { status: 'in_progress' });
+
+      expect(updated).toBeDefined();
+      expect(updated?.status).toBe('in_progress');
+      expect(updated?.id).toBe('update_test'); // ID should not change
+    });
+
+    it('should return undefined for non-existent item', () => {
+      const updated = store.update('non_existent', { status: 'completed' });
+      expect(updated).toBeUndefined();
+    });
+
+    it('should set completedAt when status changes to completed', () => {
+      const item = createMockManagedActionItem({ id: 'complete_test', status: 'pending' });
+      store.add(item);
+
+      const updated = store.update('complete_test', { status: 'completed' });
+
+      expect(updated?.status).toBe('completed');
+      expect(updated?.completedAt).toBeDefined();
+    });
+
+    it('should update isOverdue flag', () => {
+      const pastDate = '2020-01-01';
+      const item = createMockManagedActionItem({
+        id: 'overdue_test',
+        status: 'pending',
+        dueDate: pastDate,
+      });
+      store.add(item);
+
+      const updated = store.update('overdue_test', { priority: 'high' });
+
+      expect(updated?.isOverdue).toBe(true);
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete an existing item', () => {
+      const item = createMockManagedActionItem({ id: 'delete_test' });
+      store.add(item);
+
+      const deleted = store.delete('delete_test');
+
+      expect(deleted).toBe(true);
+      expect(store.get('delete_test')).toBeUndefined();
+    });
+
+    it('should return false for non-existent item', () => {
+      const deleted = store.delete('non_existent');
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('should remove all items', () => {
+      store.add(createMockManagedActionItem({ id: 'item_1' }));
+      store.add(createMockManagedActionItem({ id: 'item_2' }));
+
+      store.clear();
+
+      expect(store.getAll()).toHaveLength(0);
+    });
+  });
+});
+
+// =============================================================================
+// ActionItemService - Basic CRUD Tests
+// =============================================================================
+
+describe('ActionItemService', () => {
+  let service: ActionItemService;
+
+  beforeEach(() => {
+    const result = createTestActionItemService();
+    service = result.service;
+  });
+
+  describe('createActionItem', () => {
+    it('should create a new action item', async () => {
+      const item = createMockManagedActionItem({ id: 'create_test' });
+
+      const created = await service.createActionItem(item);
+
+      expect(created.id).toBe('create_test');
+      expect(created.content).toBe(item.content);
+    });
+
+    it('should throw error for duplicate ID', async () => {
+      const item = createMockManagedActionItem({ id: 'duplicate_test' });
+      await service.createActionItem(item);
+
+      await expect(service.createActionItem(item)).rejects.toThrow(
+        ActionItemServiceError
+      );
+      await expect(service.createActionItem(item)).rejects.toMatchObject({
+        code: 'DUPLICATE_ID',
+        statusCode: 409,
+      });
+    });
+  });
+
+  describe('getActionItem', () => {
+    it('should return action item by ID', async () => {
+      const item = createMockManagedActionItem({ id: 'get_test' });
+      await service.createActionItem(item);
+
+      const retrieved = await service.getActionItem('get_test');
+
+      expect(retrieved).not.toBeNull();
+      expect(retrieved?.id).toBe('get_test');
+    });
+
+    it('should return null for non-existent item', async () => {
+      const retrieved = await service.getActionItem('non_existent');
+      expect(retrieved).toBeNull();
+    });
+  });
+
+  describe('deleteActionItem', () => {
+    it('should delete an existing item', async () => {
+      const item = createMockManagedActionItem({ id: 'delete_service_test' });
+      await service.createActionItem(item);
+
+      await service.deleteActionItem('delete_service_test');
+
+      const retrieved = await service.getActionItem('delete_service_test');
+      expect(retrieved).toBeNull();
+    });
+
+    it('should throw ActionItemNotFoundError for non-existent item', async () => {
+      await expect(service.deleteActionItem('non_existent')).rejects.toThrow(
+        ActionItemNotFoundError
+      );
+    });
+  });
+
+  describe('updateStatus', () => {
+    it('should update item status', async () => {
+      const item = createMockManagedActionItem({
+        id: 'status_test',
+        status: 'pending',
+      });
+      await service.createActionItem(item);
+
+      const updated = await service.updateStatus('status_test', 'in_progress');
+
+      expect(updated.status).toBe('in_progress');
+    });
+
+    it('should throw ActionItemNotFoundError for non-existent item', async () => {
+      await expect(
+        service.updateStatus('non_existent', 'completed')
+      ).rejects.toThrow(ActionItemNotFoundError);
+    });
+  });
+
+  describe('updateStatusBatch', () => {
+    it('should update multiple items', async () => {
+      await service.createActionItem(
+        createMockManagedActionItem({ id: 'batch_1', status: 'pending' })
+      );
+      await service.createActionItem(
+        createMockManagedActionItem({ id: 'batch_2', status: 'pending' })
+      );
+
+      const updates = [
+        { id: 'batch_1', status: 'in_progress' as const },
+        { id: 'batch_2', status: 'completed' as const },
+      ];
+
+      const results = await service.updateStatusBatch(updates);
+
+      expect(results).toHaveLength(2);
+      expect(results.find(r => r.id === 'batch_1')?.status).toBe('in_progress');
+      expect(results.find(r => r.id === 'batch_2')?.status).toBe('completed');
+    });
+
+    it('should throw error with partial failure info', async () => {
+      await service.createActionItem(
+        createMockManagedActionItem({ id: 'batch_exists', status: 'pending' })
+      );
+
+      const updates = [
+        { id: 'batch_exists', status: 'completed' as const },
+        { id: 'batch_not_exists', status: 'completed' as const },
+      ];
+
+      await expect(service.updateStatusBatch(updates)).rejects.toMatchObject({
+        code: 'BATCH_UPDATE_PARTIAL_FAILURE',
+        details: {
+          successCount: 1,
+          errors: [{ id: 'batch_not_exists', error: 'Not found' }],
+        },
+      });
+    });
+  });
+
+  describe('updateActionItem', () => {
+    it('should update action item fields', async () => {
+      const item = createMockManagedActionItem({
+        id: 'update_fields_test',
+        content: 'Original content',
+        priority: 'low',
+      });
+      await service.createActionItem(item);
+
+      const updated = await service.updateActionItem('update_fields_test', {
+        content: 'Updated content',
+        priority: 'high',
+      });
+
+      expect(updated.content).toBe('Updated content');
+      expect(updated.priority).toBe('high');
+    });
+
+    it('should throw ActionItemNotFoundError for non-existent item', async () => {
+      await expect(
+        service.updateActionItem('non_existent', { content: 'New content' })
+      ).rejects.toThrow(ActionItemNotFoundError);
+    });
+  });
+});
+
+// =============================================================================
+// ActionItemService - Query Tests
+// =============================================================================
+
+describe('ActionItemService - Queries', () => {
+  let service: ActionItemService;
+
+  beforeEach(async () => {
+    const result = createTestActionItemService();
+    service = result.service;
+
+    // Seed test data
+    const items: ManagedActionItem[] = [
+      createMockManagedActionItem({
+        id: 'query_1',
+        meetingId: 'meeting_001',
+        status: 'pending',
+        priority: 'high',
+        dueDate: '2024-01-20',
+        assignee: { id: 'user_1', name: 'Alice' },
+      }),
+      createMockManagedActionItem({
+        id: 'query_2',
+        meetingId: 'meeting_001',
+        status: 'in_progress',
+        priority: 'medium',
+        dueDate: '2024-01-25',
+        assignee: { id: 'user_2', name: 'Bob' },
+      }),
+      createMockManagedActionItem({
+        id: 'query_3',
+        meetingId: 'meeting_002',
+        status: 'completed',
+        priority: 'low',
+        dueDate: '2024-01-15',
+        assignee: { id: 'user_1', name: 'Alice' },
+      }),
+      createMockManagedActionItem({
+        id: 'query_4',
+        meetingId: 'meeting_002',
+        status: 'pending',
+        priority: 'high',
+        isOverdue: true,
+        dueDate: '2023-12-01',
+      }),
+    ];
+
+    for (const item of items) {
+      await service.createActionItem(item);
+    }
+  });
+
+  describe('getActionItems', () => {
+    it('should return all items with default pagination', async () => {
+      const result = await service.getActionItems();
+
+      expect(result.items.length).toBe(4);
+      expect(result.pagination.total).toBe(4);
+      expect(result.pagination.page).toBe(1);
+    });
+
+    it('should apply pagination', async () => {
+      const result = await service.getActionItems(
+        undefined,
+        undefined,
+        { page: 1, pageSize: 2 }
+      );
+
+      expect(result.items.length).toBe(2);
+      expect(result.pagination.total).toBe(4);
+      expect(result.pagination.totalPages).toBe(2);
+    });
+
+    it('should return second page', async () => {
+      const page1 = await service.getActionItems(
+        undefined,
+        undefined,
+        { page: 1, pageSize: 2 }
+      );
+      const page2 = await service.getActionItems(
+        undefined,
+        undefined,
+        { page: 2, pageSize: 2 }
+      );
+
+      expect(page1.items.length).toBe(2);
+      expect(page2.items.length).toBe(2);
+
+      // Ensure different items
+      const page1Ids = page1.items.map(i => i.id);
+      const page2Ids = page2.items.map(i => i.id);
+      expect(page1Ids.some(id => page2Ids.includes(id))).toBe(false);
+    });
+  });
+
+  describe('getActionItemsByMeetingId', () => {
+    it('should return items for specific meeting', async () => {
+      const items = await service.getActionItemsByMeetingId('meeting_001');
+
+      expect(items.length).toBe(2);
+      expect(items.every(i => i.meetingId === 'meeting_001')).toBe(true);
+    });
+
+    it('should return empty array for meeting with no items', async () => {
+      const items = await service.getActionItemsByMeetingId('non_existent_meeting');
+      expect(items).toEqual([]);
+    });
+  });
+
+  describe('getAssignees', () => {
+    it('should return unique assignees', async () => {
+      const assignees = await service.getAssignees();
+
+      expect(assignees.length).toBe(2);
+      expect(assignees.map(a => a.name).sort()).toEqual(['Alice', 'Bob']);
+    });
+  });
+
+  describe('getMeetings', () => {
+    it('should return unique meetings', async () => {
+      const meetings = await service.getMeetings();
+
+      expect(meetings.length).toBe(2);
+      expect(meetings.map(m => m.id).sort()).toEqual(['meeting_001', 'meeting_002']);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return correct statistics', async () => {
+      const stats = await service.getStats();
+
+      expect(stats.total).toBe(4);
+      expect(stats.pending).toBe(2);
+      expect(stats.inProgress).toBe(1);
+      expect(stats.completed).toBe(1);
+      expect(stats.overdue).toBe(1);
+    });
+  });
+});
+
+// =============================================================================
+// ActionItemService - Filtering Tests
+// =============================================================================
+
+describe('ActionItemService - Filtering', () => {
+  let service: ActionItemService;
+
+  beforeEach(async () => {
+    const result = createTestActionItemService();
+    service = result.service;
+
+    // Seed test data
+    const items: ManagedActionItem[] = [
+      createMockManagedActionItem({
+        id: 'filter_1',
+        status: 'pending',
+        priority: 'high',
+        dueDate: '2024-01-20',
+        isOverdue: false,
+        assignee: { id: 'user_1', name: 'Alice' },
+        content: 'Review documentation',
+      }),
+      createMockManagedActionItem({
+        id: 'filter_2',
+        status: 'in_progress',
+        priority: 'medium',
+        dueDate: '2024-01-25',
+        isOverdue: false,
+        assignee: { id: 'user_2', name: 'Bob' },
+        content: 'Implement feature',
+      }),
+      createMockManagedActionItem({
+        id: 'filter_3',
+        status: 'pending',
+        priority: 'low',
+        dueDate: '2024-01-15',
+        isOverdue: true,
+        assignee: { id: 'user_1', name: 'Alice' },
+        content: 'Fix bug',
+      }),
+    ];
+
+    for (const item of items) {
+      await service.createActionItem(item);
+    }
+  });
+
+  it('should filter by status', async () => {
+    const filters: ActionItemFilters = { status: ['pending'] };
+    const result = await service.getActionItems(filters);
+
+    expect(result.items.length).toBe(2);
+    expect(result.items.every(i => i.status === 'pending')).toBe(true);
+  });
+
+  it('should filter by multiple statuses', async () => {
+    const filters: ActionItemFilters = { status: ['pending', 'in_progress'] };
+    const result = await service.getActionItems(filters);
+
+    expect(result.items.length).toBe(3);
+  });
+
+  it('should filter by priority', async () => {
+    const filters: ActionItemFilters = { priority: ['high'] };
+    const result = await service.getActionItems(filters);
+
+    expect(result.items.length).toBe(1);
+    expect(result.items[0]?.priority).toBe('high');
+  });
+
+  it('should filter by assignee', async () => {
+    const filters: ActionItemFilters = { assigneeId: 'user_1' };
+    const result = await service.getActionItems(filters);
+
+    expect(result.items.length).toBe(2);
+    expect(result.items.every(i => i.assignee?.id === 'user_1')).toBe(true);
+  });
+
+  it('should filter by overdue status', async () => {
+    const filters: ActionItemFilters = { isOverdue: true };
+    const result = await service.getActionItems(filters);
+
+    expect(result.items.length).toBe(1);
+    expect(result.items[0]?.isOverdue).toBe(true);
+  });
+
+  it('should filter by search query', async () => {
+    const filters: ActionItemFilters = { searchQuery: 'documentation' };
+    const result = await service.getActionItems(filters);
+
+    expect(result.items.length).toBe(1);
+    expect(result.items[0]?.content).toContain('documentation');
+  });
+
+  it('should filter by due date range', async () => {
+    const filters: ActionItemFilters = {
+      dueDateFrom: '2024-01-16',
+      dueDateTo: '2024-01-24',
+    };
+    const result = await service.getActionItems(filters);
+
+    expect(result.items.length).toBe(1);
+    expect(result.items[0]?.dueDate).toBe('2024-01-20');
+  });
+
+  it('should combine multiple filters', async () => {
+    const filters: ActionItemFilters = {
+      status: ['pending'],
+      assigneeId: 'user_1',
+    };
+    const result = await service.getActionItems(filters);
+
+    expect(result.items.length).toBe(2);
+    expect(result.items.every(i => i.status === 'pending' && i.assignee?.id === 'user_1')).toBe(true);
+  });
+});
+
+// =============================================================================
+// ActionItemService - Sorting Tests
+// =============================================================================
+
+describe('ActionItemService - Sorting', () => {
+  let service: ActionItemService;
+
+  beforeEach(async () => {
+    const result = createTestActionItemService();
+    service = result.service;
+
+    // Seed test data with known values
+    const items: ManagedActionItem[] = [
+      createMockManagedActionItem({
+        id: 'sort_1',
+        priority: 'low',
+        dueDate: '2024-01-25',
+        createdAt: '2024-01-10T10:00:00.000Z',
+      }),
+      createMockManagedActionItem({
+        id: 'sort_2',
+        priority: 'high',
+        dueDate: '2024-01-15',
+        createdAt: '2024-01-10T08:00:00.000Z',
+      }),
+      createMockManagedActionItem({
+        id: 'sort_3',
+        priority: 'medium',
+        dueDate: '2024-01-20',
+        createdAt: '2024-01-10T12:00:00.000Z',
+      }),
+    ];
+
+    for (const item of items) {
+      await service.createActionItem(item);
+    }
+  });
+
+  it('should sort by due date ascending', async () => {
+    const result = await service.getActionItems(
+      undefined,
+      { field: 'dueDate', order: 'asc' }
+    );
+
+    expect(result.items[0]?.dueDate).toBe('2024-01-15');
+    expect(result.items[1]?.dueDate).toBe('2024-01-20');
+    expect(result.items[2]?.dueDate).toBe('2024-01-25');
+  });
+
+  it('should sort by due date descending', async () => {
+    const result = await service.getActionItems(
+      undefined,
+      { field: 'dueDate', order: 'desc' }
+    );
+
+    expect(result.items[0]?.dueDate).toBe('2024-01-25');
+    expect(result.items[2]?.dueDate).toBe('2024-01-15');
+  });
+
+  it('should sort by priority descending (high first)', async () => {
+    const result = await service.getActionItems(
+      undefined,
+      { field: 'priority', order: 'desc' }
+    );
+
+    expect(result.items[0]?.priority).toBe('high');
+    expect(result.items[1]?.priority).toBe('medium');
+    expect(result.items[2]?.priority).toBe('low');
+  });
+
+  it('should sort by priority ascending (low first)', async () => {
+    const result = await service.getActionItems(
+      undefined,
+      { field: 'priority', order: 'asc' }
+    );
+
+    expect(result.items[0]?.priority).toBe('low');
+    expect(result.items[2]?.priority).toBe('high');
+  });
+
+  it('should sort by createdAt ascending', async () => {
+    const result = await service.getActionItems(
+      undefined,
+      { field: 'createdAt', order: 'asc' }
+    );
+
+    expect(result.items[0]?.id).toBe('sort_2'); // 08:00
+    expect(result.items[1]?.id).toBe('sort_1'); // 10:00
+    expect(result.items[2]?.id).toBe('sort_3'); // 12:00
+  });
+});
+
+// =============================================================================
+// ActionItemService - createFromMinutes Tests
+// =============================================================================
+
+describe('ActionItemService - createFromMinutes', () => {
+  let service: ActionItemService;
+
+  beforeEach(() => {
+    const result = createTestActionItemService();
+    service = result.service;
+  });
+
+  it('should create action items from minutes', async () => {
+    const minutes = createMockMinutes(3);
+    const meeting = {
+      id: 'meeting_from_minutes',
+      title: 'Planning Meeting',
+      date: '2024-01-15',
+    };
+
+    const created = await service.createFromMinutes(minutes, meeting);
+
+    expect(created.length).toBe(3);
+    expect(created.every(i => i.meetingId === 'meeting_from_minutes')).toBe(true);
+    expect(created.every(i => i.meetingTitle === 'Planning Meeting')).toBe(true);
+  });
+
+  it('should preserve action item properties', async () => {
+    const minutes = createMockMinutes(2);
+    const meeting = {
+      id: 'meeting_preserve',
+      title: 'Test Meeting',
+      date: '2024-01-15',
+    };
+
+    const created = await service.createFromMinutes(minutes, meeting);
+
+    // Check first item has high priority
+    expect(created[0]?.priority).toBe('high');
+    // Check second item has medium priority
+    expect(created[1]?.priority).toBe('medium');
+  });
+
+  it('should handle empty action items', async () => {
+    const minutes = createMockMinutes(0);
+    const meeting = {
+      id: 'meeting_empty',
+      title: 'Empty Meeting',
+      date: '2024-01-15',
+    };
+
+    const created = await service.createFromMinutes(minutes, meeting);
+
+    expect(created).toEqual([]);
+  });
+});
+
+// =============================================================================
+// Error Classes Tests
+// =============================================================================
+
+describe('Error Classes', () => {
+  describe('ActionItemServiceError', () => {
+    it('should create error with all properties', () => {
+      const error = new ActionItemServiceError(
+        'Test error',
+        'TEST_CODE',
+        400,
+        { extra: 'details' }
+      );
+
+      expect(error.message).toBe('Test error');
+      expect(error.code).toBe('TEST_CODE');
+      expect(error.statusCode).toBe(400);
+      expect(error.details).toEqual({ extra: 'details' });
+      expect(error.name).toBe('ActionItemServiceError');
+    });
+
+    it('should use default statusCode of 500', () => {
+      const error = new ActionItemServiceError('Test error', 'TEST_CODE');
+      expect(error.statusCode).toBe(500);
+    });
+  });
+
+  describe('ActionItemNotFoundError', () => {
+    it('should create error with correct properties', () => {
+      const error = new ActionItemNotFoundError('test_id_123');
+
+      expect(error.message).toBe("Action item with id 'test_id_123' not found");
+      expect(error.code).toBe('NOT_FOUND');
+      expect(error.statusCode).toBe(404);
+      expect(error.details).toEqual({ id: 'test_id_123' });
+      expect(error.name).toBe('ActionItemNotFoundError');
+    });
+  });
+});
+
+// =============================================================================
+// Factory Functions Tests
+// =============================================================================
+
+describe('Factory Functions', () => {
+  describe('createActionItemService', () => {
+    it('should create service instance', () => {
+      // Reset singleton before test
+      ActionItemStore.resetInstance();
+
+      const service = createActionItemService();
+      expect(service).toBeInstanceOf(ActionItemService);
+    });
+  });
+
+  describe('createTestActionItemService', () => {
+    it('should create service with isolated store', async () => {
+      const { service: service1, store: store1 } = createTestActionItemService();
+      const { service: service2, store: store2 } = createTestActionItemService();
+
+      // Add item to first service
+      await service1.createActionItem(
+        createMockManagedActionItem({ id: 'isolated_test' })
+      );
+
+      // Second service should not see it
+      const item = await service2.getActionItem('isolated_test');
+      expect(item).toBeNull();
+
+      // But first service should
+      const found = await service1.getActionItem('isolated_test');
+      expect(found).not.toBeNull();
+
+      // Stores should be different instances
+      expect(store1).not.toBe(store2);
+    });
+  });
+});
+
+// =============================================================================
+// Edge Cases Tests
+// =============================================================================
+
+describe('Edge Cases', () => {
+  let service: ActionItemService;
+
+  beforeEach(() => {
+    const result = createTestActionItemService();
+    service = result.service;
+  });
+
+  it('should handle empty filters object', async () => {
+    await service.createActionItem(createMockManagedActionItem({ id: 'edge_1' }));
+
+    const result = await service.getActionItems({});
+    expect(result.items.length).toBe(1);
+  });
+
+  it('should handle page beyond total', async () => {
+    await service.createActionItem(createMockManagedActionItem({ id: 'edge_2' }));
+
+    const result = await service.getActionItems(
+      undefined,
+      undefined,
+      { page: 100, pageSize: 10 }
+    );
+
+    // createPagination normalizes page to valid range, so we get the last valid page
+    // With 1 item and pageSize 10, totalPages is 1, so page is clamped to 1
+    expect(result.items.length).toBe(1);
+    expect(result.pagination.total).toBe(1);
+    expect(result.pagination.page).toBe(1); // Normalized to valid page
+    expect(result.pagination.totalPages).toBe(1);
+  });
+
+  it('should handle clearAll', async () => {
+    await service.createActionItem(createMockManagedActionItem({ id: 'clear_1' }));
+    await service.createActionItem(createMockManagedActionItem({ id: 'clear_2' }));
+
+    await service.clearAll();
+
+    const result = await service.getActionItems();
+    expect(result.items.length).toBe(0);
+  });
+
+  it('should handle items without assignee', async () => {
+    const item = createMockManagedActionItem({ id: 'no_assignee' });
+    delete (item as Partial<ManagedActionItem>).assignee;
+    await service.createActionItem(item);
+
+    const assignees = await service.getAssignees();
+    expect(assignees.length).toBe(0);
+  });
+
+  it('should handle items without dueDate in sorting', async () => {
+    const itemWithDate = createMockManagedActionItem({
+      id: 'with_date',
+      dueDate: '2024-01-15',
+    });
+    const itemWithoutDate = createMockManagedActionItem({ id: 'without_date' });
+    delete (itemWithoutDate as Partial<ManagedActionItem>).dueDate;
+
+    await service.createActionItem(itemWithDate);
+    await service.createActionItem(itemWithoutDate);
+
+    const result = await service.getActionItems(
+      undefined,
+      { field: 'dueDate', order: 'asc' }
+    );
+
+    // Items without dueDate should be at the end
+    expect(result.items[0]?.id).toBe('with_date');
+    expect(result.items[1]?.id).toBe('without_date');
+  });
+});

--- a/src/services/action-item.service.ts
+++ b/src/services/action-item.service.ts
@@ -1,0 +1,498 @@
+/**
+ * ActionItem service for CRUD operations
+ * @module services/action-item.service
+ */
+
+import type {
+  ManagedActionItem,
+  ActionItemFilters,
+  ActionItemSortOptions,
+  ActionItemListResponse,
+  ActionItemStatusUpdate,
+  ActionItemStats,
+} from '@/types/action-item';
+import {
+  filterActionItems,
+  sortManagedActionItems,
+  createPagination,
+  paginateItems,
+  getActionItemStats,
+  toManagedActionItem,
+  isActionItemOverdue,
+} from '@/types/action-item';
+import type { Minutes, Speaker, ActionItemStatus } from '@/types/minutes';
+
+// ============================================================================
+// Error Classes
+// ============================================================================
+
+/**
+ * General ActionItem service error
+ */
+export class ActionItemServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly statusCode: number = 500,
+    public readonly details?: unknown
+  ) {
+    super(message);
+    this.name = 'ActionItemServiceError';
+  }
+}
+
+/**
+ * ActionItem not found error
+ */
+export class ActionItemNotFoundError extends ActionItemServiceError {
+  constructor(id: string) {
+    super(`Action item with id '${id}' not found`, 'NOT_FOUND', 404, { id });
+    this.name = 'ActionItemNotFoundError';
+  }
+}
+
+// ============================================================================
+// In-Memory Store (Singleton)
+// ============================================================================
+
+/**
+ * In-memory storage for action items
+ * (Phase 2 temporary implementation - will be replaced with Lark Base in Phase 2-3)
+ */
+class ActionItemStore {
+  private items: Map<string, ManagedActionItem> = new Map();
+  private static instance: ActionItemStore | undefined;
+
+  /**
+   * Get singleton instance
+   */
+  static getInstance(): ActionItemStore {
+    if (ActionItemStore.instance === undefined) {
+      ActionItemStore.instance = new ActionItemStore();
+    }
+    return ActionItemStore.instance;
+  }
+
+  /**
+   * Reset singleton instance (for testing)
+   */
+  static resetInstance(): void {
+    ActionItemStore.instance = undefined;
+  }
+
+  /**
+   * Add an item to the store
+   */
+  add(item: ManagedActionItem): void {
+    this.items.set(item.id, item);
+  }
+
+  /**
+   * Get an item by ID
+   */
+  get(id: string): ManagedActionItem | undefined {
+    return this.items.get(id);
+  }
+
+  /**
+   * Get all items
+   */
+  getAll(): ManagedActionItem[] {
+    return Array.from(this.items.values());
+  }
+
+  /**
+   * Update an item
+   */
+  update(
+    id: string,
+    updates: Partial<ManagedActionItem>
+  ): ManagedActionItem | undefined {
+    const existing = this.items.get(id);
+    if (existing === undefined) {
+      return undefined;
+    }
+
+    const updated: ManagedActionItem = {
+      ...existing,
+      ...updates,
+      id: existing.id, // Prevent ID from being changed
+      updatedAt: new Date().toISOString(),
+    };
+
+    // Update isOverdue flag
+    updated.isOverdue = isActionItemOverdue(updated);
+
+    // Set completedAt if status changed to completed
+    if (updates.status === 'completed' && existing.status !== 'completed') {
+      updated.completedAt = new Date().toISOString();
+    }
+
+    this.items.set(id, updated);
+    return updated;
+  }
+
+  /**
+   * Delete an item
+   */
+  delete(id: string): boolean {
+    return this.items.delete(id);
+  }
+
+  /**
+   * Clear all items
+   */
+  clear(): void {
+    this.items.clear();
+  }
+
+  /**
+   * Get item count
+   */
+  get size(): number {
+    return this.items.size;
+  }
+}
+
+// ============================================================================
+// Default Values
+// ============================================================================
+
+const DEFAULT_SORT: ActionItemSortOptions = {
+  field: 'dueDate',
+  order: 'asc',
+};
+
+const DEFAULT_PAGE_SIZE = 20;
+
+// ============================================================================
+// ActionItemService
+// ============================================================================
+
+/**
+ * Service for managing action items with CRUD operations
+ */
+export class ActionItemService {
+  private readonly store: ActionItemStore;
+
+  constructor(store?: ActionItemStore) {
+    this.store = store ?? ActionItemStore.getInstance();
+  }
+
+  /**
+   * Get paginated list of action items with filtering and sorting
+   *
+   * @param filters - Filter criteria
+   * @param sort - Sort options
+   * @param pagination - Pagination options
+   * @returns Paginated list response
+   */
+  async getActionItems(
+    filters?: ActionItemFilters,
+    sort?: ActionItemSortOptions,
+    pagination?: { page: number; pageSize: number }
+  ): Promise<ActionItemListResponse> {
+    // Note: async for future Lark Base integration
+    const allItems = await Promise.resolve(this.store.getAll());
+    const appliedFilters = filters ?? {};
+    const appliedSort = sort ?? DEFAULT_SORT;
+    const page = pagination?.page ?? 1;
+    const pageSize = pagination?.pageSize ?? DEFAULT_PAGE_SIZE;
+
+    // Apply filters
+    const filteredItems = filterActionItems(allItems, appliedFilters);
+
+    // Apply sorting
+    const sortedItems = sortManagedActionItems(filteredItems, appliedSort);
+
+    // Create pagination info
+    const paginationInfo = createPagination(sortedItems.length, page, pageSize);
+
+    // Apply pagination
+    const paginatedItems = paginateItems(
+      sortedItems,
+      paginationInfo.page,
+      pageSize
+    );
+
+    return {
+      items: paginatedItems,
+      pagination: paginationInfo,
+      filters: appliedFilters,
+      sort: appliedSort,
+    };
+  }
+
+  /**
+   * Get a single action item by ID
+   *
+   * @param id - Action item ID
+   * @returns ManagedActionItem or null if not found
+   */
+  async getActionItem(id: string): Promise<ManagedActionItem | null> {
+    // Note: async for future Lark Base integration
+    const item = await Promise.resolve(this.store.get(id));
+    return item ?? null;
+  }
+
+  /**
+   * Get all action items for a specific meeting
+   *
+   * @param meetingId - Meeting ID
+   * @returns Array of action items for the meeting
+   */
+  async getActionItemsByMeetingId(
+    meetingId: string
+  ): Promise<ManagedActionItem[]> {
+    // Note: async for future Lark Base integration
+    const allItems = await Promise.resolve(this.store.getAll());
+    return allItems.filter((item) => item.meetingId === meetingId);
+  }
+
+  /**
+   * Update the status of an action item
+   *
+   * @param id - Action item ID
+   * @param status - New status
+   * @returns Updated action item
+   * @throws ActionItemNotFoundError if item not found
+   */
+  async updateStatus(
+    id: string,
+    status: ActionItemStatus
+  ): Promise<ManagedActionItem> {
+    // Note: async for future Lark Base integration
+    const updated = await Promise.resolve(this.store.update(id, { status }));
+    if (updated === undefined) {
+      throw new ActionItemNotFoundError(id);
+    }
+    return updated;
+  }
+
+  /**
+   * Batch update status for multiple action items
+   *
+   * @param updates - Array of status updates
+   * @returns Array of updated action items
+   * @throws ActionItemServiceError if any update fails
+   */
+  async updateStatusBatch(
+    updates: ActionItemStatusUpdate[]
+  ): Promise<ManagedActionItem[]> {
+    // Note: async for future Lark Base integration
+    const results: ManagedActionItem[] = [];
+    const errors: Array<{ id: string; error: string }> = [];
+
+    for (const update of updates) {
+      const existing = await Promise.resolve(this.store.get(update.id));
+      if (existing === undefined) {
+        errors.push({ id: update.id, error: 'Not found' });
+        continue;
+      }
+
+      const updated = this.store.update(update.id, { status: update.status });
+      if (updated !== undefined) {
+        results.push(updated);
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new ActionItemServiceError(
+        `Failed to update ${errors.length} action item(s)`,
+        'BATCH_UPDATE_PARTIAL_FAILURE',
+        400,
+        { errors, successCount: results.length }
+      );
+    }
+
+    return results;
+  }
+
+  /**
+   * Create action items from minutes
+   *
+   * @param minutes - Minutes containing action items
+   * @param meeting - Meeting information
+   * @returns Array of created ManagedActionItems
+   */
+  async createFromMinutes(
+    minutes: Minutes,
+    meeting: { id: string; title: string; date: string }
+  ): Promise<ManagedActionItem[]> {
+    // Note: async for future Lark Base integration
+    const createdItems: ManagedActionItem[] = [];
+
+    for (const actionItem of minutes.actionItems) {
+      // Find source text from topics if relatedTopicId is provided
+      let sourceText: string | undefined;
+      if (actionItem.relatedTopicId !== undefined) {
+        const relatedTopic = minutes.topics.find(
+          (topic) => topic.id === actionItem.relatedTopicId
+        );
+        if (relatedTopic !== undefined) {
+          sourceText = relatedTopic.summary;
+        }
+      }
+
+      const managedItem = toManagedActionItem(actionItem, meeting, sourceText);
+      await Promise.resolve(this.store.add(managedItem));
+      createdItems.push(managedItem);
+    }
+
+    return createdItems;
+  }
+
+  /**
+   * Create a single action item
+   *
+   * @param item - ManagedActionItem to create
+   * @returns Created action item
+   * @throws ActionItemServiceError if item with same ID already exists
+   */
+  async createActionItem(item: ManagedActionItem): Promise<ManagedActionItem> {
+    // Note: async for future Lark Base integration
+    const existing = await Promise.resolve(this.store.get(item.id));
+    if (existing !== undefined) {
+      throw new ActionItemServiceError(
+        `Action item with id '${item.id}' already exists`,
+        'DUPLICATE_ID',
+        409,
+        { id: item.id }
+      );
+    }
+
+    await Promise.resolve(this.store.add(item));
+    return item;
+  }
+
+  /**
+   * Delete an action item
+   *
+   * @param id - Action item ID
+   * @throws ActionItemNotFoundError if item not found
+   */
+  async deleteActionItem(id: string): Promise<void> {
+    // Note: async for future Lark Base integration
+    const deleted = await Promise.resolve(this.store.delete(id));
+    if (!deleted) {
+      throw new ActionItemNotFoundError(id);
+    }
+  }
+
+  /**
+   * Get action item statistics
+   *
+   * @returns Statistics about all action items
+   */
+  async getStats(): Promise<ActionItemStats> {
+    // Note: async for future Lark Base integration
+    const allItems = await Promise.resolve(this.store.getAll());
+    return getActionItemStats(allItems);
+  }
+
+  /**
+   * Get unique list of assignees
+   *
+   * @returns Array of unique speakers who have action items assigned
+   */
+  async getAssignees(): Promise<Speaker[]> {
+    // Note: async for future Lark Base integration
+    const allItems = await Promise.resolve(this.store.getAll());
+    const assigneeMap = new Map<string, Speaker>();
+
+    for (const item of allItems) {
+      if (item.assignee !== undefined) {
+        assigneeMap.set(item.assignee.id, item.assignee);
+      }
+    }
+
+    return Array.from(assigneeMap.values());
+  }
+
+  /**
+   * Get unique list of meetings
+   *
+   * @returns Array of unique meeting references
+   */
+  async getMeetings(): Promise<Array<{ id: string; title: string }>> {
+    // Note: async for future Lark Base integration
+    const allItems = await Promise.resolve(this.store.getAll());
+    const meetingMap = new Map<string, { id: string; title: string }>();
+
+    for (const item of allItems) {
+      if (!meetingMap.has(item.meetingId)) {
+        meetingMap.set(item.meetingId, {
+          id: item.meetingId,
+          title: item.meetingTitle,
+        });
+      }
+    }
+
+    return Array.from(meetingMap.values());
+  }
+
+  /**
+   * Update action item fields
+   *
+   * @param id - Action item ID
+   * @param updates - Fields to update
+   * @returns Updated action item
+   * @throws ActionItemNotFoundError if item not found
+   */
+  async updateActionItem(
+    id: string,
+    updates: Partial<
+      Pick<
+        ManagedActionItem,
+        'content' | 'assignee' | 'dueDate' | 'priority' | 'status'
+      >
+    >
+  ): Promise<ManagedActionItem> {
+    // Note: async for future Lark Base integration
+    const updated = await Promise.resolve(this.store.update(id, updates));
+    if (updated === undefined) {
+      throw new ActionItemNotFoundError(id);
+    }
+    return updated;
+  }
+
+  /**
+   * Clear all action items (for testing)
+   */
+  async clearAll(): Promise<void> {
+    // Note: async for future Lark Base integration
+    await Promise.resolve(this.store.clear());
+  }
+}
+
+// ============================================================================
+// Factory Function
+// ============================================================================
+
+/**
+ * Create an ActionItemService instance
+ *
+ * @returns ActionItemService instance using singleton store
+ */
+export function createActionItemService(): ActionItemService {
+  return new ActionItemService();
+}
+
+/**
+ * Create an ActionItemService instance with a fresh store (for testing)
+ *
+ * @returns ActionItemService instance with isolated store
+ */
+export function createTestActionItemService(): {
+  service: ActionItemService;
+  store: ActionItemStore;
+} {
+  const store = new (ActionItemStore as unknown as {
+    new (): ActionItemStore;
+  })();
+  const service = new ActionItemService(store);
+  return { service, store };
+}
+
+// Export store class for testing
+export { ActionItemStore };

--- a/src/types/action-item.ts
+++ b/src/types/action-item.ts
@@ -1,0 +1,876 @@
+/**
+ * Extended ActionItem type definitions for action item management
+ * @module types/action-item
+ */
+
+import { z } from 'zod';
+import {
+  ActionItem,
+  ActionItemSchema,
+  ActionItemStatus,
+  ActionItemStatusSchema,
+  Priority,
+  PrioritySchema,
+  generateId,
+} from './minutes';
+
+// ============================================================================
+// Zod Schemas
+// ============================================================================
+
+/**
+ * Zod schema for ManagedActionItem (extended ActionItem with management fields)
+ */
+export const ManagedActionItemSchema = ActionItemSchema.extend({
+  /** Meeting ID where this action item was extracted */
+  meetingId: z.string().min(1),
+  /** Meeting title */
+  meetingTitle: z.string().min(1),
+  /** Meeting date in ISO format */
+  meetingDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Must be ISO date format YYYY-MM-DD'),
+
+  /** Source text from which the action item was extracted */
+  sourceText: z.string().optional(),
+  /** Extraction timestamp in ISO format */
+  extractedAt: z.string().datetime({ offset: true }),
+
+  /** Creation timestamp in ISO format */
+  createdAt: z.string().datetime({ offset: true }),
+  /** Last update timestamp in ISO format */
+  updatedAt: z.string().datetime({ offset: true }),
+  /** Completion timestamp in ISO format (only when status is 'completed') */
+  completedAt: z.string().datetime({ offset: true }).optional(),
+
+  /** Whether the action item is past its due date */
+  isOverdue: z.boolean(),
+});
+
+/**
+ * Zod schema for ActionItemFilters
+ */
+export const ActionItemFiltersSchema = z.object({
+  /** Filter by status(es) */
+  status: z.array(ActionItemStatusSchema).optional(),
+  /** Filter by priority/priorities */
+  priority: z.array(PrioritySchema).optional(),
+  /** Filter by assignee ID */
+  assigneeId: z.string().optional(),
+  /** Filter by meeting ID */
+  meetingId: z.string().optional(),
+  /** Filter by overdue status */
+  isOverdue: z.boolean().optional(),
+  /** Filter by due date range start (inclusive) */
+  dueDateFrom: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  /** Filter by due date range end (inclusive) */
+  dueDateTo: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  /** Text search query */
+  searchQuery: z.string().optional(),
+});
+
+/**
+ * Sort field for action items
+ */
+export const ActionItemSortFieldSchema = z.enum([
+  'dueDate',
+  'priority',
+  'status',
+  'createdAt',
+  'meetingDate',
+]);
+
+/**
+ * Sort order (ascending or descending)
+ */
+export const SortOrderSchema = z.enum(['asc', 'desc']);
+
+/**
+ * Zod schema for ActionItemSortOptions
+ */
+export const ActionItemSortOptionsSchema = z.object({
+  /** Field to sort by */
+  field: ActionItemSortFieldSchema,
+  /** Sort order */
+  order: SortOrderSchema,
+});
+
+/**
+ * Zod schema for ActionItemPagination
+ */
+export const ActionItemPaginationSchema = z.object({
+  /** Current page number (1-indexed) */
+  page: z.number().int().positive(),
+  /** Number of items per page */
+  pageSize: z.number().int().positive(),
+  /** Total number of items */
+  total: z.number().int().nonnegative(),
+  /** Total number of pages */
+  totalPages: z.number().int().nonnegative(),
+});
+
+/**
+ * Zod schema for ActionItemListResponse
+ */
+export const ActionItemListResponseSchema = z.object({
+  /** List of action items */
+  items: z.array(ManagedActionItemSchema),
+  /** Pagination information */
+  pagination: ActionItemPaginationSchema,
+  /** Applied filters */
+  filters: ActionItemFiltersSchema,
+  /** Applied sort options */
+  sort: ActionItemSortOptionsSchema,
+});
+
+/**
+ * Zod schema for ActionItemStatusUpdate
+ */
+export const ActionItemStatusUpdateSchema = z.object({
+  /** Action item ID to update */
+  id: z.string().min(1),
+  /** New status */
+  status: ActionItemStatusSchema,
+});
+
+/**
+ * Zod schema for ActionItemStats
+ */
+export const ActionItemStatsSchema = z.object({
+  /** Total number of action items */
+  total: z.number().int().nonnegative(),
+  /** Number of pending items */
+  pending: z.number().int().nonnegative(),
+  /** Number of in-progress items */
+  inProgress: z.number().int().nonnegative(),
+  /** Number of completed items */
+  completed: z.number().int().nonnegative(),
+  /** Number of overdue items */
+  overdue: z.number().int().nonnegative(),
+});
+
+// ============================================================================
+// Types (inferred from Zod schemas)
+// ============================================================================
+
+/**
+ * Extended ActionItem with management and tracking fields
+ */
+export type ManagedActionItem = z.infer<typeof ManagedActionItemSchema>;
+
+/**
+ * Filter options for querying action items
+ */
+export type ActionItemFilters = z.infer<typeof ActionItemFiltersSchema>;
+
+/**
+ * Available sort fields for action items
+ */
+export type ActionItemSortField = z.infer<typeof ActionItemSortFieldSchema>;
+
+/**
+ * Sort order direction
+ */
+export type SortOrder = z.infer<typeof SortOrderSchema>;
+
+/**
+ * Sort options for action item queries
+ */
+export type ActionItemSortOptions = z.infer<typeof ActionItemSortOptionsSchema>;
+
+/**
+ * Pagination information for action item lists
+ */
+export type ActionItemPagination = z.infer<typeof ActionItemPaginationSchema>;
+
+/**
+ * Response structure for action item list queries
+ */
+export type ActionItemListResponse = z.infer<typeof ActionItemListResponseSchema>;
+
+/**
+ * Request structure for updating action item status
+ */
+export type ActionItemStatusUpdate = z.infer<typeof ActionItemStatusUpdateSchema>;
+
+/**
+ * Statistics about action items
+ */
+export type ActionItemStats = z.infer<typeof ActionItemStatsSchema>;
+
+// ============================================================================
+// Read-only Types
+// ============================================================================
+
+/**
+ * Read-only ManagedActionItem type
+ */
+export interface ReadonlyManagedActionItem {
+  readonly id: string;
+  readonly content: string;
+  readonly assignee?: {
+    readonly id: string;
+    readonly name: string;
+    readonly larkUserId?: string | undefined;
+  } | undefined;
+  readonly dueDate?: string | undefined;
+  readonly priority: Priority;
+  readonly status: ActionItemStatus;
+  readonly relatedTopicId?: string | undefined;
+  readonly meetingId: string;
+  readonly meetingTitle: string;
+  readonly meetingDate: string;
+  readonly sourceText?: string | undefined;
+  readonly extractedAt: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly completedAt?: string | undefined;
+  readonly isOverdue: boolean;
+}
+
+/**
+ * Read-only ActionItemFilters type
+ */
+export interface ReadonlyActionItemFilters {
+  readonly status?: readonly ActionItemStatus[] | undefined;
+  readonly priority?: readonly Priority[] | undefined;
+  readonly assigneeId?: string | undefined;
+  readonly meetingId?: string | undefined;
+  readonly isOverdue?: boolean | undefined;
+  readonly dueDateFrom?: string | undefined;
+  readonly dueDateTo?: string | undefined;
+  readonly searchQuery?: string | undefined;
+}
+
+/**
+ * Read-only ActionItemStats type
+ */
+export interface ReadonlyActionItemStats {
+  readonly total: number;
+  readonly pending: number;
+  readonly inProgress: number;
+  readonly completed: number;
+  readonly overdue: number;
+}
+
+// ============================================================================
+// Meeting Info Type (for toManagedActionItem)
+// ============================================================================
+
+/**
+ * Meeting information for action item conversion
+ */
+export interface MeetingInfo {
+  id: string;
+  title: string;
+  date: string;
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Priority order mapping for sorting
+ */
+const PRIORITY_ORDER: Record<Priority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+/**
+ * Status order mapping for sorting
+ */
+const STATUS_ORDER: Record<ActionItemStatus, number> = {
+  pending: 0,
+  in_progress: 1,
+  completed: 2,
+};
+
+/**
+ * Check if an action item is overdue
+ *
+ * @param item - Action item to check
+ * @returns true if the item has a due date and is past it, false otherwise
+ *
+ * @example
+ * ```typescript
+ * const item = { dueDate: '2024-01-01', status: 'pending', ... };
+ * const overdue = isActionItemOverdue(item);
+ * // Returns true if today is after 2024-01-01
+ * ```
+ */
+export function isActionItemOverdue(item: ActionItem): boolean {
+  if (item.dueDate === undefined) {
+    return false;
+  }
+  if (item.status === 'completed') {
+    return false;
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const dueDate = new Date(item.dueDate);
+  dueDate.setHours(0, 0, 0, 0);
+
+  return dueDate < today;
+}
+
+/**
+ * Sort action items by priority
+ *
+ * @param items - Array of action items to sort
+ * @param order - Sort order ('asc' for low->high, 'desc' for high->low). Default: 'desc' (high first)
+ * @returns New sorted array of action items
+ *
+ * @example
+ * ```typescript
+ * const sorted = sortByPriority(items);
+ * // sorted[0].priority === 'high'
+ *
+ * const sortedAsc = sortByPriority(items, 'asc');
+ * // sortedAsc[0].priority === 'low'
+ * ```
+ */
+export function sortByPriority<T extends ActionItem>(
+  items: readonly T[],
+  order: SortOrder = 'desc'
+): T[] {
+  const sorted = [...items].sort(
+    (a, b) => PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]
+  );
+  return order === 'asc' ? sorted.reverse() : sorted;
+}
+
+/**
+ * Sort action items by due date
+ *
+ * @param items - Array of action items to sort
+ * @param order - Sort order ('asc' for earliest first, 'desc' for latest first). Default: 'asc'
+ * @returns New sorted array of action items (items without due date are placed at the end)
+ *
+ * @example
+ * ```typescript
+ * const sorted = sortByDueDate(items);
+ * // Items with earliest due dates first, items without due dates at end
+ * ```
+ */
+export function sortByDueDate<T extends ActionItem>(
+  items: readonly T[],
+  order: SortOrder = 'asc'
+): T[] {
+  return [...items].sort((a, b) => {
+    // Items without due date go to the end
+    if (a.dueDate === undefined && b.dueDate === undefined) {
+      return 0;
+    }
+    if (a.dueDate === undefined) {
+      return 1;
+    }
+    if (b.dueDate === undefined) {
+      return -1;
+    }
+
+    const dateA = new Date(a.dueDate).getTime();
+    const dateB = new Date(b.dueDate).getTime();
+    const comparison = dateA - dateB;
+
+    return order === 'asc' ? comparison : -comparison;
+  });
+}
+
+/**
+ * Filter managed action items based on filter criteria
+ *
+ * @param items - Array of managed action items to filter
+ * @param filters - Filter criteria
+ * @returns Filtered array of managed action items
+ *
+ * @example
+ * ```typescript
+ * const filtered = filterActionItems(items, {
+ *   status: ['pending', 'in_progress'],
+ *   priority: ['high'],
+ *   isOverdue: true,
+ * });
+ * ```
+ */
+export function filterActionItems(
+  items: readonly ManagedActionItem[],
+  filters: ActionItemFilters
+): ManagedActionItem[] {
+  let result = [...items];
+
+  // Filter by status
+  if (filters.status !== undefined && filters.status.length > 0) {
+    result = result.filter((item) => filters.status!.includes(item.status));
+  }
+
+  // Filter by priority
+  if (filters.priority !== undefined && filters.priority.length > 0) {
+    result = result.filter((item) => filters.priority!.includes(item.priority));
+  }
+
+  // Filter by assignee ID
+  if (filters.assigneeId !== undefined) {
+    result = result.filter((item) => item.assignee?.id === filters.assigneeId);
+  }
+
+  // Filter by meeting ID
+  if (filters.meetingId !== undefined) {
+    result = result.filter((item) => item.meetingId === filters.meetingId);
+  }
+
+  // Filter by overdue status
+  if (filters.isOverdue !== undefined) {
+    result = result.filter((item) => item.isOverdue === filters.isOverdue);
+  }
+
+  // Filter by due date range (from)
+  if (filters.dueDateFrom !== undefined) {
+    const fromDate = new Date(filters.dueDateFrom);
+    fromDate.setHours(0, 0, 0, 0);
+    result = result.filter((item) => {
+      if (item.dueDate === undefined) {
+        return false;
+      }
+      const itemDate = new Date(item.dueDate);
+      itemDate.setHours(0, 0, 0, 0);
+      return itemDate >= fromDate;
+    });
+  }
+
+  // Filter by due date range (to)
+  if (filters.dueDateTo !== undefined) {
+    const toDate = new Date(filters.dueDateTo);
+    toDate.setHours(0, 0, 0, 0);
+    result = result.filter((item) => {
+      if (item.dueDate === undefined) {
+        return false;
+      }
+      const itemDate = new Date(item.dueDate);
+      itemDate.setHours(0, 0, 0, 0);
+      return itemDate <= toDate;
+    });
+  }
+
+  // Filter by search query (searches in content, meetingTitle, and assignee name)
+  if (filters.searchQuery !== undefined && filters.searchQuery.trim() !== '') {
+    const query = filters.searchQuery.toLowerCase().trim();
+    result = result.filter((item) => {
+      const contentMatch = item.content.toLowerCase().includes(query);
+      const titleMatch = item.meetingTitle.toLowerCase().includes(query);
+      const assigneeMatch = item.assignee?.name.toLowerCase().includes(query) ?? false;
+      const sourceMatch = item.sourceText?.toLowerCase().includes(query) ?? false;
+      return contentMatch || titleMatch || assigneeMatch || sourceMatch;
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Convert a basic ActionItem to a ManagedActionItem
+ *
+ * @param item - Basic action item to convert
+ * @param meeting - Meeting information (id, title, date)
+ * @param sourceText - Optional source text from which the item was extracted
+ * @returns ManagedActionItem with all management fields populated
+ *
+ * @example
+ * ```typescript
+ * const managed = toManagedActionItem(actionItem, {
+ *   id: 'meeting-123',
+ *   title: 'Weekly Sync',
+ *   date: '2024-01-15',
+ * });
+ * ```
+ */
+export function toManagedActionItem(
+  item: ActionItem,
+  meeting: MeetingInfo,
+  sourceText?: string
+): ManagedActionItem {
+  const now = new Date().toISOString();
+  const isOverdue = isActionItemOverdue(item);
+
+  const base: ManagedActionItem = {
+    ...item,
+    meetingId: meeting.id,
+    meetingTitle: meeting.title,
+    meetingDate: meeting.date,
+    extractedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    isOverdue,
+  };
+
+  if (sourceText !== undefined) {
+    return { ...base, sourceText };
+  }
+
+  return base;
+}
+
+/**
+ * Calculate the number of days until due date
+ *
+ * @param dueDate - Due date in ISO format (YYYY-MM-DD)
+ * @returns Number of days until due (negative if overdue, 0 if due today)
+ *
+ * @example
+ * ```typescript
+ * const days = getDaysUntilDue('2024-01-15');
+ * // Returns -5 if today is 2024-01-20 (5 days overdue)
+ * // Returns 5 if today is 2024-01-10 (5 days until due)
+ * // Returns 0 if today is 2024-01-15 (due today)
+ * ```
+ */
+export function getDaysUntilDue(dueDate: string): number {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const due = new Date(dueDate);
+  due.setHours(0, 0, 0, 0);
+
+  const diffMs = due.getTime() - today.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  return diffDays;
+}
+
+/**
+ * Get statistics about managed action items
+ *
+ * @param items - Array of managed action items
+ * @returns Statistics object with counts for each category
+ *
+ * @example
+ * ```typescript
+ * const stats = getActionItemStats(items);
+ * // { total: 10, pending: 4, inProgress: 3, completed: 3, overdue: 2 }
+ * ```
+ */
+export function getActionItemStats(
+  items: readonly ManagedActionItem[]
+): ActionItemStats {
+  const stats = {
+    total: items.length,
+    pending: 0,
+    inProgress: 0,
+    completed: 0,
+    overdue: 0,
+  };
+
+  for (const item of items) {
+    switch (item.status) {
+      case 'pending':
+        stats.pending++;
+        break;
+      case 'in_progress':
+        stats.inProgress++;
+        break;
+      case 'completed':
+        stats.completed++;
+        break;
+    }
+
+    if (item.isOverdue) {
+      stats.overdue++;
+    }
+  }
+
+  return stats;
+}
+
+/**
+ * Sort managed action items by the specified field and order
+ *
+ * @param items - Array of managed action items to sort
+ * @param options - Sort options (field and order)
+ * @returns New sorted array of managed action items
+ *
+ * @example
+ * ```typescript
+ * const sorted = sortManagedActionItems(items, { field: 'dueDate', order: 'asc' });
+ * ```
+ */
+export function sortManagedActionItems(
+  items: readonly ManagedActionItem[],
+  options: ActionItemSortOptions
+): ManagedActionItem[] {
+  const { field, order } = options;
+
+  switch (field) {
+    case 'dueDate':
+      return sortByDueDate(items, order);
+
+    case 'priority':
+      return sortByPriority(items, order);
+
+    case 'status':
+      return [...items].sort((a, b) => {
+        const comparison = STATUS_ORDER[a.status] - STATUS_ORDER[b.status];
+        return order === 'asc' ? comparison : -comparison;
+      });
+
+    case 'createdAt':
+      return [...items].sort((a, b) => {
+        const dateA = new Date(a.createdAt).getTime();
+        const dateB = new Date(b.createdAt).getTime();
+        const comparison = dateA - dateB;
+        return order === 'asc' ? comparison : -comparison;
+      });
+
+    case 'meetingDate':
+      return [...items].sort((a, b) => {
+        const dateA = new Date(a.meetingDate).getTime();
+        const dateB = new Date(b.meetingDate).getTime();
+        const comparison = dateA - dateB;
+        return order === 'asc' ? comparison : -comparison;
+      });
+
+    default:
+      return [...items];
+  }
+}
+
+/**
+ * Create pagination info for action item list
+ *
+ * @param totalItems - Total number of items
+ * @param page - Current page (1-indexed)
+ * @param pageSize - Items per page
+ * @returns ActionItemPagination object
+ */
+export function createPagination(
+  totalItems: number,
+  page: number,
+  pageSize: number
+): ActionItemPagination {
+  const totalPages = Math.max(1, Math.ceil(totalItems / pageSize));
+  const validPage = Math.min(Math.max(1, page), totalPages);
+
+  return {
+    page: validPage,
+    pageSize,
+    total: totalItems,
+    totalPages,
+  };
+}
+
+/**
+ * Apply pagination to an array of items
+ *
+ * @param items - Array of items to paginate
+ * @param page - Page number (1-indexed)
+ * @param pageSize - Items per page
+ * @returns Paginated slice of items
+ */
+export function paginateItems<T>(
+  items: readonly T[],
+  page: number,
+  pageSize: number
+): T[] {
+  const startIndex = (page - 1) * pageSize;
+  return items.slice(startIndex, startIndex + pageSize);
+}
+
+/**
+ * Create a complete list response for action items
+ *
+ * @param items - All managed action items
+ * @param filters - Filter criteria
+ * @param sort - Sort options
+ * @param page - Page number (1-indexed)
+ * @param pageSize - Items per page
+ * @returns Complete ActionItemListResponse
+ */
+export function createActionItemListResponse(
+  items: readonly ManagedActionItem[],
+  filters: ActionItemFilters,
+  sort: ActionItemSortOptions,
+  page: number,
+  pageSize: number
+): ActionItemListResponse {
+  // Apply filters
+  const filteredItems = filterActionItems(items, filters);
+
+  // Apply sorting
+  const sortedItems = sortManagedActionItems(filteredItems, sort);
+
+  // Create pagination
+  const pagination = createPagination(sortedItems.length, page, pageSize);
+
+  // Apply pagination
+  const paginatedItems = paginateItems(sortedItems, pagination.page, pageSize);
+
+  return {
+    items: paginatedItems,
+    pagination,
+    filters,
+    sort,
+  };
+}
+
+/**
+ * Update the isOverdue flag for all items based on current date
+ *
+ * @param items - Array of managed action items
+ * @returns New array with updated isOverdue flags
+ */
+export function refreshOverdueStatus(
+  items: readonly ManagedActionItem[]
+): ManagedActionItem[] {
+  return items.map((item) => ({
+    ...item,
+    isOverdue: isActionItemOverdue(item),
+    updatedAt: new Date().toISOString(),
+  }));
+}
+
+/**
+ * Create a new ManagedActionItem
+ *
+ * @param content - Task content
+ * @param meeting - Meeting information
+ * @param options - Optional properties
+ * @returns New ManagedActionItem
+ */
+export function createManagedActionItem(
+  content: string,
+  meeting: MeetingInfo,
+  options?: Partial<{
+    priority: Priority;
+    status: ActionItemStatus;
+    assignee: ManagedActionItem['assignee'];
+    dueDate: string;
+    relatedTopicId: string;
+    sourceText: string;
+  }>
+): ManagedActionItem {
+  const now = new Date().toISOString();
+  const priority = options?.priority ?? 'medium';
+  const status = options?.status ?? 'pending';
+  const dueDate = options?.dueDate;
+
+  const base: ManagedActionItem = {
+    id: generateId('action'),
+    content,
+    priority,
+    status,
+    meetingId: meeting.id,
+    meetingTitle: meeting.title,
+    meetingDate: meeting.date,
+    extractedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    isOverdue: dueDate !== undefined
+      ? isActionItemOverdue({ id: '', content: '', priority, status, dueDate })
+      : false,
+  };
+
+  // Add optional properties
+  if (options?.assignee !== undefined) {
+    base.assignee = options.assignee;
+  }
+  if (options?.dueDate !== undefined) {
+    base.dueDate = options.dueDate;
+  }
+  if (options?.relatedTopicId !== undefined) {
+    base.relatedTopicId = options.relatedTopicId;
+  }
+  if (options?.sourceText !== undefined) {
+    base.sourceText = options.sourceText;
+  }
+
+  return base;
+}
+
+// ============================================================================
+// Validation Functions
+// ============================================================================
+
+/**
+ * Validate a ManagedActionItem using Zod schema
+ *
+ * @param data - Data to validate
+ * @returns Validation result with success flag and data/error
+ */
+export function validateManagedActionItem(
+  data: unknown
+): z.SafeParseReturnType<unknown, ManagedActionItem> {
+  return ManagedActionItemSchema.safeParse(data);
+}
+
+/**
+ * Validate ActionItemFilters using Zod schema
+ *
+ * @param data - Data to validate
+ * @returns Validation result with success flag and data/error
+ */
+export function validateActionItemFilters(
+  data: unknown
+): z.SafeParseReturnType<unknown, ActionItemFilters> {
+  return ActionItemFiltersSchema.safeParse(data);
+}
+
+/**
+ * Validate ActionItemSortOptions using Zod schema
+ *
+ * @param data - Data to validate
+ * @returns Validation result with success flag and data/error
+ */
+export function validateActionItemSortOptions(
+  data: unknown
+): z.SafeParseReturnType<unknown, ActionItemSortOptions> {
+  return ActionItemSortOptionsSchema.safeParse(data);
+}
+
+/**
+ * Validate ActionItemPagination using Zod schema
+ *
+ * @param data - Data to validate
+ * @returns Validation result with success flag and data/error
+ */
+export function validateActionItemPagination(
+  data: unknown
+): z.SafeParseReturnType<unknown, ActionItemPagination> {
+  return ActionItemPaginationSchema.safeParse(data);
+}
+
+/**
+ * Validate ActionItemListResponse using Zod schema
+ *
+ * @param data - Data to validate
+ * @returns Validation result with success flag and data/error
+ */
+export function validateActionItemListResponse(
+  data: unknown
+): z.SafeParseReturnType<unknown, ActionItemListResponse> {
+  return ActionItemListResponseSchema.safeParse(data);
+}
+
+/**
+ * Validate ActionItemStatusUpdate using Zod schema
+ *
+ * @param data - Data to validate
+ * @returns Validation result with success flag and data/error
+ */
+export function validateActionItemStatusUpdate(
+  data: unknown
+): z.SafeParseReturnType<unknown, ActionItemStatusUpdate> {
+  return ActionItemStatusUpdateSchema.safeParse(data);
+}
+
+/**
+ * Validate ActionItemStats using Zod schema
+ *
+ * @param data - Data to validate
+ * @returns Validation result with success flag and data/error
+ */
+export function validateActionItemStats(
+  data: unknown
+): z.SafeParseReturnType<unknown, ActionItemStats> {
+  return ActionItemStatsSchema.safeParse(data);
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,3 +60,54 @@ export {
 
 // Export types
 export * from './export';
+
+// Action Item extended types - for action item management
+// Note: Some types use aliases to avoid collisions with component types
+export {
+  // Zod Schemas
+  ManagedActionItemSchema,
+  ActionItemFiltersSchema as ActionItemFiltersDataSchema,
+  ActionItemSortFieldSchema,
+  SortOrderSchema,
+  ActionItemSortOptionsSchema as ActionItemSortOptionsDataSchema,
+  ActionItemPaginationSchema,
+  ActionItemListResponseSchema,
+  ActionItemStatusUpdateSchema,
+  ActionItemStatsSchema as ActionItemStatsDataSchema,
+  // Types
+  type ManagedActionItem as ManagedActionItemData,
+  type ActionItemFilters as ActionItemFiltersData,
+  type ActionItemSortField as ActionItemSortFieldData,
+  type SortOrder,
+  type ActionItemSortOptions as ActionItemSortOptionsData,
+  type ActionItemPagination,
+  type ActionItemListResponse,
+  type ActionItemStatusUpdate,
+  type ActionItemStats as ActionItemStatsData,
+  type ReadonlyManagedActionItem,
+  type ReadonlyActionItemFilters,
+  type ReadonlyActionItemStats,
+  type MeetingInfo,
+  // Utility functions
+  isActionItemOverdue,
+  sortByPriority,
+  sortByDueDate,
+  filterActionItems,
+  toManagedActionItem,
+  getDaysUntilDue,
+  getActionItemStats,
+  sortManagedActionItems,
+  createPagination,
+  paginateItems,
+  createActionItemListResponse,
+  refreshOverdueStatus,
+  createManagedActionItem,
+  // Validation functions
+  validateManagedActionItem,
+  validateActionItemFilters,
+  validateActionItemSortOptions,
+  validateActionItemPagination,
+  validateActionItemListResponse,
+  validateActionItemStatusUpdate,
+  validateActionItemStats,
+} from './action-item';

--- a/tests/types/action-item.test.ts
+++ b/tests/types/action-item.test.ts
@@ -1,0 +1,1149 @@
+/**
+ * Unit tests for action-item type definitions, Zod schemas, and utility functions
+ * @module tests/types/action-item
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  // Schemas
+  ManagedActionItemSchema,
+  ActionItemFiltersSchema,
+  ActionItemSortFieldSchema,
+  SortOrderSchema,
+  ActionItemSortOptionsSchema,
+  ActionItemPaginationSchema,
+  ActionItemListResponseSchema,
+  ActionItemStatusUpdateSchema,
+  ActionItemStatsSchema,
+  // Types
+  type ManagedActionItem,
+  type ActionItemFilters,
+  type ActionItemSortField,
+  type SortOrder,
+  type ActionItemSortOptions,
+  type ActionItemPagination,
+  type ActionItemListResponse,
+  type ActionItemStatusUpdate,
+  type ActionItemStats,
+  type MeetingInfo,
+  // Utility functions
+  isActionItemOverdue,
+  sortByPriority,
+  sortByDueDate,
+  filterActionItems,
+  toManagedActionItem,
+  getDaysUntilDue,
+  getActionItemStats,
+  sortManagedActionItems,
+  createPagination,
+  paginateItems,
+  createActionItemListResponse,
+  refreshOverdueStatus,
+  createManagedActionItem,
+  // Validation functions
+  validateManagedActionItem,
+  validateActionItemFilters,
+  validateActionItemSortOptions,
+  validateActionItemPagination,
+  validateActionItemListResponse,
+  validateActionItemStatusUpdate,
+  validateActionItemStats,
+} from '@/types/action-item';
+import {
+  type ActionItem,
+  type Speaker,
+  createActionItem,
+  createSpeaker,
+} from '@/types/minutes';
+
+// ============================================================================
+// Test Data Fixtures
+// ============================================================================
+
+const testMeeting: MeetingInfo = {
+  id: 'meeting-123',
+  title: 'Weekly Team Sync',
+  date: '2024-01-15',
+};
+
+const testSpeaker: Speaker = {
+  id: 'speaker-1',
+  name: 'Alice Smith',
+};
+
+const testSpeaker2: Speaker = {
+  id: 'speaker-2',
+  name: 'Bob Johnson',
+};
+
+function createTestActionItem(
+  overrides: Partial<ActionItem> = {}
+): ActionItem {
+  const base: ActionItem = {
+    id: 'action-1',
+    content: 'Complete the project documentation',
+    priority: 'medium',
+    status: 'pending',
+  };
+
+  if (overrides.assignee !== undefined) {
+    (base as ActionItem).assignee = overrides.assignee;
+  }
+  if (overrides.dueDate !== undefined) {
+    (base as ActionItem).dueDate = overrides.dueDate;
+  }
+  if (overrides.relatedTopicId !== undefined) {
+    (base as ActionItem).relatedTopicId = overrides.relatedTopicId;
+  }
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+function createTestManagedActionItem(
+  overrides: Partial<ManagedActionItem> = {}
+): ManagedActionItem {
+  const now = new Date().toISOString();
+  const base: ManagedActionItem = {
+    id: 'action-1',
+    content: 'Complete the project documentation',
+    priority: 'medium',
+    status: 'pending',
+    meetingId: 'meeting-123',
+    meetingTitle: 'Weekly Team Sync',
+    meetingDate: '2024-01-15',
+    extractedAt: now,
+    createdAt: now,
+    updatedAt: now,
+    isOverdue: false,
+  };
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Zod Schema Tests
+// ============================================================================
+
+describe('Zod Schemas', () => {
+  describe('ManagedActionItemSchema', () => {
+    it('should validate a complete managed action item', () => {
+      const item = createTestManagedActionItem({
+        assignee: testSpeaker,
+        dueDate: '2024-02-01',
+        sourceText: 'We need to complete the documentation by next month',
+        completedAt: undefined,
+      });
+
+      const result = ManagedActionItemSchema.safeParse(item);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate minimal managed action item', () => {
+      const item = createTestManagedActionItem();
+
+      const result = ManagedActionItemSchema.safeParse(item);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject invalid meeting ID', () => {
+      const item = createTestManagedActionItem({ meetingId: '' });
+
+      const result = ManagedActionItemSchema.safeParse(item);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject invalid meeting date format', () => {
+      const item = createTestManagedActionItem({ meetingDate: '2024/01/15' });
+
+      const result = ManagedActionItemSchema.safeParse(item);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject invalid extractedAt format', () => {
+      const item = createTestManagedActionItem({ extractedAt: 'not-a-date' });
+
+      const result = ManagedActionItemSchema.safeParse(item);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('ActionItemFiltersSchema', () => {
+    it('should validate empty filters', () => {
+      const filters = {};
+
+      const result = ActionItemFiltersSchema.safeParse(filters);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate complete filters', () => {
+      const filters: ActionItemFilters = {
+        status: ['pending', 'in_progress'],
+        priority: ['high', 'medium'],
+        assigneeId: 'speaker-1',
+        meetingId: 'meeting-123',
+        isOverdue: true,
+        dueDateFrom: '2024-01-01',
+        dueDateTo: '2024-12-31',
+        searchQuery: 'documentation',
+      };
+
+      const result = ActionItemFiltersSchema.safeParse(filters);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject invalid status', () => {
+      const filters = {
+        status: ['invalid-status'],
+      };
+
+      const result = ActionItemFiltersSchema.safeParse(filters);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject invalid due date format', () => {
+      const filters = {
+        dueDateFrom: '01-01-2024',
+      };
+
+      const result = ActionItemFiltersSchema.safeParse(filters);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('ActionItemSortOptionsSchema', () => {
+    it('should validate valid sort options', () => {
+      const options: ActionItemSortOptions = {
+        field: 'dueDate',
+        order: 'asc',
+      };
+
+      const result = ActionItemSortOptionsSchema.safeParse(options);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate all sort fields', () => {
+      const fields: ActionItemSortField[] = [
+        'dueDate',
+        'priority',
+        'status',
+        'createdAt',
+        'meetingDate',
+      ];
+
+      for (const field of fields) {
+        const result = ActionItemSortOptionsSchema.safeParse({
+          field,
+          order: 'desc',
+        });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it('should reject invalid sort field', () => {
+      const options = {
+        field: 'invalidField',
+        order: 'asc',
+      };
+
+      const result = ActionItemSortOptionsSchema.safeParse(options);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('ActionItemPaginationSchema', () => {
+    it('should validate valid pagination', () => {
+      const pagination: ActionItemPagination = {
+        page: 1,
+        pageSize: 10,
+        total: 100,
+        totalPages: 10,
+      };
+
+      const result = ActionItemPaginationSchema.safeParse(pagination);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject non-positive page', () => {
+      const pagination = {
+        page: 0,
+        pageSize: 10,
+        total: 100,
+        totalPages: 10,
+      };
+
+      const result = ActionItemPaginationSchema.safeParse(pagination);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject negative total', () => {
+      const pagination = {
+        page: 1,
+        pageSize: 10,
+        total: -1,
+        totalPages: 0,
+      };
+
+      const result = ActionItemPaginationSchema.safeParse(pagination);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('ActionItemStatusUpdateSchema', () => {
+    it('should validate valid status update', () => {
+      const update: ActionItemStatusUpdate = {
+        id: 'action-1',
+        status: 'completed',
+      };
+
+      const result = ActionItemStatusUpdateSchema.safeParse(update);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject empty id', () => {
+      const update = {
+        id: '',
+        status: 'completed',
+      };
+
+      const result = ActionItemStatusUpdateSchema.safeParse(update);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('ActionItemStatsSchema', () => {
+    it('should validate valid stats', () => {
+      const stats: ActionItemStats = {
+        total: 10,
+        pending: 4,
+        inProgress: 3,
+        completed: 3,
+        overdue: 2,
+      };
+
+      const result = ActionItemStatsSchema.safeParse(stats);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject negative values', () => {
+      const stats = {
+        total: -1,
+        pending: 4,
+        inProgress: 3,
+        completed: 3,
+        overdue: 2,
+      };
+
+      const result = ActionItemStatsSchema.safeParse(stats);
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+// ============================================================================
+// Utility Function Tests
+// ============================================================================
+
+describe('Utility Functions', () => {
+  describe('isActionItemOverdue', () => {
+    beforeEach(() => {
+      // Mock current date to 2024-01-15
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-15'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should return false for items without due date', () => {
+      const item = createTestActionItem();
+      expect(isActionItemOverdue(item)).toBe(false);
+    });
+
+    it('should return false for completed items', () => {
+      const item = createTestActionItem({
+        dueDate: '2024-01-01', // Past due
+        status: 'completed',
+      });
+      expect(isActionItemOverdue(item)).toBe(false);
+    });
+
+    it('should return true for past due pending items', () => {
+      const item = createTestActionItem({
+        dueDate: '2024-01-14', // Yesterday
+        status: 'pending',
+      });
+      expect(isActionItemOverdue(item)).toBe(true);
+    });
+
+    it('should return false for future due items', () => {
+      const item = createTestActionItem({
+        dueDate: '2024-01-16', // Tomorrow
+        status: 'pending',
+      });
+      expect(isActionItemOverdue(item)).toBe(false);
+    });
+
+    it('should return false for items due today', () => {
+      const item = createTestActionItem({
+        dueDate: '2024-01-15', // Today
+        status: 'pending',
+      });
+      expect(isActionItemOverdue(item)).toBe(false);
+    });
+  });
+
+  describe('sortByPriority', () => {
+    it('should sort by priority descending (high first) by default', () => {
+      const items = [
+        createTestActionItem({ id: '1', priority: 'low' }),
+        createTestActionItem({ id: '2', priority: 'high' }),
+        createTestActionItem({ id: '3', priority: 'medium' }),
+      ];
+
+      const sorted = sortByPriority(items);
+
+      expect(sorted[0]?.priority).toBe('high');
+      expect(sorted[1]?.priority).toBe('medium');
+      expect(sorted[2]?.priority).toBe('low');
+    });
+
+    it('should sort by priority ascending when specified', () => {
+      const items = [
+        createTestActionItem({ id: '1', priority: 'high' }),
+        createTestActionItem({ id: '2', priority: 'low' }),
+        createTestActionItem({ id: '3', priority: 'medium' }),
+      ];
+
+      const sorted = sortByPriority(items, 'asc');
+
+      expect(sorted[0]?.priority).toBe('low');
+      expect(sorted[1]?.priority).toBe('medium');
+      expect(sorted[2]?.priority).toBe('high');
+    });
+
+    it('should not mutate the original array', () => {
+      const items = [
+        createTestActionItem({ id: '1', priority: 'low' }),
+        createTestActionItem({ id: '2', priority: 'high' }),
+      ];
+      const originalFirst = items[0];
+
+      sortByPriority(items);
+
+      expect(items[0]).toBe(originalFirst);
+    });
+  });
+
+  describe('sortByDueDate', () => {
+    it('should sort by due date ascending by default', () => {
+      const items = [
+        createTestActionItem({ id: '1', dueDate: '2024-03-01' }),
+        createTestActionItem({ id: '2', dueDate: '2024-01-01' }),
+        createTestActionItem({ id: '3', dueDate: '2024-02-01' }),
+      ];
+
+      const sorted = sortByDueDate(items);
+
+      expect(sorted[0]?.dueDate).toBe('2024-01-01');
+      expect(sorted[1]?.dueDate).toBe('2024-02-01');
+      expect(sorted[2]?.dueDate).toBe('2024-03-01');
+    });
+
+    it('should sort by due date descending when specified', () => {
+      const items = [
+        createTestActionItem({ id: '1', dueDate: '2024-01-01' }),
+        createTestActionItem({ id: '2', dueDate: '2024-03-01' }),
+        createTestActionItem({ id: '3', dueDate: '2024-02-01' }),
+      ];
+
+      const sorted = sortByDueDate(items, 'desc');
+
+      expect(sorted[0]?.dueDate).toBe('2024-03-01');
+      expect(sorted[1]?.dueDate).toBe('2024-02-01');
+      expect(sorted[2]?.dueDate).toBe('2024-01-01');
+    });
+
+    it('should place items without due date at the end', () => {
+      const items = [
+        createTestActionItem({ id: '1' }), // No due date
+        createTestActionItem({ id: '2', dueDate: '2024-01-01' }),
+        createTestActionItem({ id: '3' }), // No due date
+      ];
+
+      const sorted = sortByDueDate(items);
+
+      expect(sorted[0]?.dueDate).toBe('2024-01-01');
+      expect(sorted[1]?.dueDate).toBeUndefined();
+      expect(sorted[2]?.dueDate).toBeUndefined();
+    });
+  });
+
+  describe('filterActionItems', () => {
+    const items: ManagedActionItem[] = [
+      createTestManagedActionItem({
+        id: '1',
+        status: 'pending',
+        priority: 'high',
+        assignee: testSpeaker,
+        meetingId: 'meeting-1',
+        dueDate: '2024-01-10',
+        isOverdue: true,
+      }),
+      createTestManagedActionItem({
+        id: '2',
+        status: 'in_progress',
+        priority: 'medium',
+        assignee: testSpeaker2,
+        meetingId: 'meeting-2',
+        dueDate: '2024-01-20',
+        isOverdue: false,
+      }),
+      createTestManagedActionItem({
+        id: '3',
+        status: 'completed',
+        priority: 'low',
+        meetingId: 'meeting-1',
+        isOverdue: false,
+      }),
+    ];
+
+    it('should return all items with empty filters', () => {
+      const filtered = filterActionItems(items, {});
+      expect(filtered).toHaveLength(3);
+    });
+
+    it('should filter by status', () => {
+      const filtered = filterActionItems(items, {
+        status: ['pending', 'in_progress'],
+      });
+      expect(filtered).toHaveLength(2);
+      expect(filtered.every((i) => ['pending', 'in_progress'].includes(i.status))).toBe(true);
+    });
+
+    it('should filter by priority', () => {
+      const filtered = filterActionItems(items, {
+        priority: ['high'],
+      });
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]?.priority).toBe('high');
+    });
+
+    it('should filter by assignee ID', () => {
+      const filtered = filterActionItems(items, {
+        assigneeId: 'speaker-1',
+      });
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]?.assignee?.id).toBe('speaker-1');
+    });
+
+    it('should filter by meeting ID', () => {
+      const filtered = filterActionItems(items, {
+        meetingId: 'meeting-1',
+      });
+      expect(filtered).toHaveLength(2);
+    });
+
+    it('should filter by overdue status', () => {
+      const filtered = filterActionItems(items, {
+        isOverdue: true,
+      });
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]?.id).toBe('1');
+    });
+
+    it('should filter by due date range', () => {
+      const filtered = filterActionItems(items, {
+        dueDateFrom: '2024-01-15',
+        dueDateTo: '2024-01-25',
+      });
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]?.dueDate).toBe('2024-01-20');
+    });
+
+    it('should filter by search query in content', () => {
+      const itemsWithContent: ManagedActionItem[] = [
+        createTestManagedActionItem({
+          id: '1',
+          content: 'Write documentation',
+        }),
+        createTestManagedActionItem({
+          id: '2',
+          content: 'Fix bugs',
+        }),
+      ];
+
+      const filtered = filterActionItems(itemsWithContent, {
+        searchQuery: 'document',
+      });
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]?.content).toContain('documentation');
+    });
+
+    it('should combine multiple filters', () => {
+      const filtered = filterActionItems(items, {
+        status: ['pending'],
+        priority: ['high'],
+        isOverdue: true,
+      });
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]?.id).toBe('1');
+    });
+  });
+
+  describe('toManagedActionItem', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-15T10:00:00Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should convert basic action item to managed action item', () => {
+      const actionItem = createTestActionItem({
+        dueDate: '2024-01-20',
+      });
+
+      const managed = toManagedActionItem(actionItem, testMeeting);
+
+      expect(managed.meetingId).toBe(testMeeting.id);
+      expect(managed.meetingTitle).toBe(testMeeting.title);
+      expect(managed.meetingDate).toBe(testMeeting.date);
+      expect(managed.isOverdue).toBe(false);
+      expect(managed.createdAt).toBeDefined();
+      expect(managed.updatedAt).toBeDefined();
+    });
+
+    it('should include source text when provided', () => {
+      const actionItem = createTestActionItem();
+      const sourceText = 'We need to do this by next week';
+
+      const managed = toManagedActionItem(actionItem, testMeeting, sourceText);
+
+      expect(managed.sourceText).toBe(sourceText);
+    });
+
+    it('should detect overdue items', () => {
+      const actionItem = createTestActionItem({
+        dueDate: '2024-01-10', // Past
+        status: 'pending',
+      });
+
+      const managed = toManagedActionItem(actionItem, testMeeting);
+
+      expect(managed.isOverdue).toBe(true);
+    });
+  });
+
+  describe('getDaysUntilDue', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-15'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should return positive days for future dates', () => {
+      expect(getDaysUntilDue('2024-01-20')).toBe(5);
+    });
+
+    it('should return negative days for past dates', () => {
+      expect(getDaysUntilDue('2024-01-10')).toBe(-5);
+    });
+
+    it('should return 0 for today', () => {
+      expect(getDaysUntilDue('2024-01-15')).toBe(0);
+    });
+  });
+
+  describe('getActionItemStats', () => {
+    it('should calculate correct statistics', () => {
+      const items: ManagedActionItem[] = [
+        createTestManagedActionItem({ status: 'pending', isOverdue: true }),
+        createTestManagedActionItem({ status: 'pending', isOverdue: false }),
+        createTestManagedActionItem({ status: 'in_progress', isOverdue: true }),
+        createTestManagedActionItem({ status: 'completed', isOverdue: false }),
+      ];
+
+      const stats = getActionItemStats(items);
+
+      expect(stats.total).toBe(4);
+      expect(stats.pending).toBe(2);
+      expect(stats.inProgress).toBe(1);
+      expect(stats.completed).toBe(1);
+      expect(stats.overdue).toBe(2);
+    });
+
+    it('should return zeros for empty array', () => {
+      const stats = getActionItemStats([]);
+
+      expect(stats.total).toBe(0);
+      expect(stats.pending).toBe(0);
+      expect(stats.inProgress).toBe(0);
+      expect(stats.completed).toBe(0);
+      expect(stats.overdue).toBe(0);
+    });
+  });
+
+  describe('sortManagedActionItems', () => {
+    const items: ManagedActionItem[] = [
+      createTestManagedActionItem({
+        id: '1',
+        priority: 'low',
+        status: 'completed',
+        dueDate: '2024-03-01',
+        createdAt: '2024-01-03T00:00:00Z',
+        meetingDate: '2024-01-03',
+      }),
+      createTestManagedActionItem({
+        id: '2',
+        priority: 'high',
+        status: 'pending',
+        dueDate: '2024-01-01',
+        createdAt: '2024-01-01T00:00:00Z',
+        meetingDate: '2024-01-01',
+      }),
+      createTestManagedActionItem({
+        id: '3',
+        priority: 'medium',
+        status: 'in_progress',
+        dueDate: '2024-02-01',
+        createdAt: '2024-01-02T00:00:00Z',
+        meetingDate: '2024-01-02',
+      }),
+    ];
+
+    it('should sort by priority', () => {
+      const sorted = sortManagedActionItems(items, { field: 'priority', order: 'desc' });
+      expect(sorted[0]?.priority).toBe('high');
+      expect(sorted[1]?.priority).toBe('medium');
+      expect(sorted[2]?.priority).toBe('low');
+    });
+
+    it('should sort by status', () => {
+      const sorted = sortManagedActionItems(items, { field: 'status', order: 'asc' });
+      expect(sorted[0]?.status).toBe('pending');
+      expect(sorted[1]?.status).toBe('in_progress');
+      expect(sorted[2]?.status).toBe('completed');
+    });
+
+    it('should sort by createdAt', () => {
+      const sorted = sortManagedActionItems(items, { field: 'createdAt', order: 'asc' });
+      expect(sorted[0]?.id).toBe('2');
+      expect(sorted[1]?.id).toBe('3');
+      expect(sorted[2]?.id).toBe('1');
+    });
+
+    it('should sort by meetingDate', () => {
+      const sorted = sortManagedActionItems(items, { field: 'meetingDate', order: 'desc' });
+      expect(sorted[0]?.meetingDate).toBe('2024-01-03');
+      expect(sorted[1]?.meetingDate).toBe('2024-01-02');
+      expect(sorted[2]?.meetingDate).toBe('2024-01-01');
+    });
+  });
+
+  describe('createPagination', () => {
+    it('should create correct pagination for first page', () => {
+      const pagination = createPagination(100, 1, 10);
+
+      expect(pagination.page).toBe(1);
+      expect(pagination.pageSize).toBe(10);
+      expect(pagination.total).toBe(100);
+      expect(pagination.totalPages).toBe(10);
+    });
+
+    it('should handle partial last page', () => {
+      const pagination = createPagination(95, 1, 10);
+
+      expect(pagination.totalPages).toBe(10);
+    });
+
+    it('should clamp page to valid range', () => {
+      const pagination = createPagination(100, 15, 10);
+
+      expect(pagination.page).toBe(10); // Max valid page
+    });
+
+    it('should handle zero items', () => {
+      const pagination = createPagination(0, 1, 10);
+
+      expect(pagination.total).toBe(0);
+      expect(pagination.totalPages).toBe(1);
+      expect(pagination.page).toBe(1);
+    });
+  });
+
+  describe('paginateItems', () => {
+    const items = Array.from({ length: 25 }, (_, i) =>
+      createTestManagedActionItem({ id: `item-${i + 1}` })
+    );
+
+    it('should return correct items for first page', () => {
+      const result = paginateItems(items, 1, 10);
+
+      expect(result).toHaveLength(10);
+      expect(result[0]?.id).toBe('item-1');
+      expect(result[9]?.id).toBe('item-10');
+    });
+
+    it('should return correct items for middle page', () => {
+      const result = paginateItems(items, 2, 10);
+
+      expect(result).toHaveLength(10);
+      expect(result[0]?.id).toBe('item-11');
+      expect(result[9]?.id).toBe('item-20');
+    });
+
+    it('should return remaining items for last partial page', () => {
+      const result = paginateItems(items, 3, 10);
+
+      expect(result).toHaveLength(5);
+      expect(result[0]?.id).toBe('item-21');
+      expect(result[4]?.id).toBe('item-25');
+    });
+
+    it('should return empty array for out of range page', () => {
+      const result = paginateItems(items, 10, 10);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('createActionItemListResponse', () => {
+    const items: ManagedActionItem[] = [
+      createTestManagedActionItem({
+        id: '1',
+        status: 'pending',
+        priority: 'high',
+        dueDate: '2024-02-01',
+      }),
+      createTestManagedActionItem({
+        id: '2',
+        status: 'pending',
+        priority: 'medium',
+        dueDate: '2024-01-15',
+      }),
+      createTestManagedActionItem({
+        id: '3',
+        status: 'completed',
+        priority: 'low',
+      }),
+    ];
+
+    it('should create complete response with filters and sorting', () => {
+      const filters: ActionItemFilters = { status: ['pending'] };
+      const sort: ActionItemSortOptions = { field: 'priority', order: 'desc' };
+
+      const response = createActionItemListResponse(items, filters, sort, 1, 10);
+
+      expect(response.items).toHaveLength(2);
+      expect(response.items[0]?.priority).toBe('high');
+      expect(response.pagination.total).toBe(2);
+      expect(response.filters).toEqual(filters);
+      expect(response.sort).toEqual(sort);
+    });
+
+    it('should apply pagination correctly', () => {
+      const allPendingItems = Array.from({ length: 25 }, (_, i) =>
+        createTestManagedActionItem({ id: `item-${i + 1}`, status: 'pending' })
+      );
+
+      const response = createActionItemListResponse(
+        allPendingItems,
+        {},
+        { field: 'createdAt', order: 'asc' },
+        2,
+        10
+      );
+
+      expect(response.items).toHaveLength(10);
+      expect(response.pagination.page).toBe(2);
+      expect(response.pagination.totalPages).toBe(3);
+    });
+  });
+
+  describe('refreshOverdueStatus', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-15'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should update overdue status for all items', () => {
+      const items: ManagedActionItem[] = [
+        createTestManagedActionItem({
+          id: '1',
+          dueDate: '2024-01-10',
+          status: 'pending',
+          isOverdue: false, // Wrong, should be true
+        }),
+        createTestManagedActionItem({
+          id: '2',
+          dueDate: '2024-01-20',
+          status: 'pending',
+          isOverdue: true, // Wrong, should be false
+        }),
+      ];
+
+      const refreshed = refreshOverdueStatus(items);
+
+      expect(refreshed[0]?.isOverdue).toBe(true);
+      expect(refreshed[1]?.isOverdue).toBe(false);
+    });
+
+    it('should not mutate original array', () => {
+      const items: ManagedActionItem[] = [
+        createTestManagedActionItem({ isOverdue: false }),
+      ];
+      const original = items[0]?.isOverdue;
+
+      refreshOverdueStatus(items);
+
+      expect(items[0]?.isOverdue).toBe(original);
+    });
+  });
+
+  describe('createManagedActionItem', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2024-01-15T10:00:00Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should create minimal managed action item', () => {
+      const item = createManagedActionItem('Complete task', testMeeting);
+
+      expect(item.content).toBe('Complete task');
+      expect(item.meetingId).toBe(testMeeting.id);
+      expect(item.priority).toBe('medium');
+      expect(item.status).toBe('pending');
+      expect(item.isOverdue).toBe(false);
+      expect(item.id).toMatch(/^action_/);
+    });
+
+    it('should create managed action item with all options', () => {
+      const item = createManagedActionItem('Complete task', testMeeting, {
+        priority: 'high',
+        status: 'in_progress',
+        assignee: testSpeaker,
+        dueDate: '2024-01-20',
+        relatedTopicId: 'topic-1',
+        sourceText: 'Original speech',
+      });
+
+      expect(item.priority).toBe('high');
+      expect(item.status).toBe('in_progress');
+      expect(item.assignee).toEqual(testSpeaker);
+      expect(item.dueDate).toBe('2024-01-20');
+      expect(item.relatedTopicId).toBe('topic-1');
+      expect(item.sourceText).toBe('Original speech');
+    });
+
+    it('should detect overdue status on creation', () => {
+      const item = createManagedActionItem('Complete task', testMeeting, {
+        dueDate: '2024-01-10', // Past
+      });
+
+      expect(item.isOverdue).toBe(true);
+    });
+  });
+});
+
+// ============================================================================
+// Validation Function Tests
+// ============================================================================
+
+describe('Validation Functions', () => {
+  describe('validateManagedActionItem', () => {
+    it('should validate correct data', () => {
+      const item = createTestManagedActionItem();
+      const result = validateManagedActionItem(item);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual(item);
+      }
+    });
+
+    it('should reject invalid data', () => {
+      const result = validateManagedActionItem({});
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('validateActionItemFilters', () => {
+    it('should validate correct filters', () => {
+      const filters: ActionItemFilters = {
+        status: ['pending'],
+        priority: ['high'],
+      };
+      const result = validateActionItemFilters(filters);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate empty filters', () => {
+      const result = validateActionItemFilters({});
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('validateActionItemSortOptions', () => {
+    it('should validate correct sort options', () => {
+      const options: ActionItemSortOptions = {
+        field: 'dueDate',
+        order: 'asc',
+      };
+      const result = validateActionItemSortOptions(options);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('validateActionItemPagination', () => {
+    it('should validate correct pagination', () => {
+      const pagination: ActionItemPagination = {
+        page: 1,
+        pageSize: 10,
+        total: 100,
+        totalPages: 10,
+      };
+      const result = validateActionItemPagination(pagination);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('validateActionItemListResponse', () => {
+    it('should validate correct response', () => {
+      const response: ActionItemListResponse = {
+        items: [createTestManagedActionItem()],
+        pagination: {
+          page: 1,
+          pageSize: 10,
+          total: 1,
+          totalPages: 1,
+        },
+        filters: {},
+        sort: {
+          field: 'dueDate',
+          order: 'asc',
+        },
+      };
+      const result = validateActionItemListResponse(response);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('validateActionItemStatusUpdate', () => {
+    it('should validate correct update', () => {
+      const update: ActionItemStatusUpdate = {
+        id: 'action-1',
+        status: 'completed',
+      };
+      const result = validateActionItemStatusUpdate(update);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('validateActionItemStats', () => {
+    it('should validate correct stats', () => {
+      const stats: ActionItemStats = {
+        total: 10,
+        pending: 4,
+        inProgress: 3,
+        completed: 3,
+        overdue: 2,
+      };
+      const result = validateActionItemStats(stats);
+
+      expect(result.success).toBe(true);
+    });
+  });
+});
+
+// ============================================================================
+// Type Tests (compile-time verification)
+// ============================================================================
+
+describe('Type Definitions', () => {
+  it('should enforce correct ManagedActionItem type', () => {
+    // This test verifies that types are correctly defined
+    const item: ManagedActionItem = {
+      id: 'action-1',
+      content: 'Task content',
+      priority: 'high',
+      status: 'pending',
+      meetingId: 'meeting-1',
+      meetingTitle: 'Meeting Title',
+      meetingDate: '2024-01-15',
+      extractedAt: '2024-01-15T00:00:00Z',
+      createdAt: '2024-01-15T00:00:00Z',
+      updatedAt: '2024-01-15T00:00:00Z',
+      isOverdue: false,
+    };
+
+    expect(item).toBeDefined();
+  });
+
+  it('should allow optional fields to be undefined', () => {
+    const item: ManagedActionItem = {
+      id: 'action-1',
+      content: 'Task content',
+      priority: 'high',
+      status: 'pending',
+      meetingId: 'meeting-1',
+      meetingTitle: 'Meeting Title',
+      meetingDate: '2024-01-15',
+      extractedAt: '2024-01-15T00:00:00Z',
+      createdAt: '2024-01-15T00:00:00Z',
+      updatedAt: '2024-01-15T00:00:00Z',
+      isOverdue: false,
+      // Optional fields not set
+    };
+
+    expect(item.assignee).toBeUndefined();
+    expect(item.dueDate).toBeUndefined();
+    expect(item.sourceText).toBeUndefined();
+    expect(item.completedAt).toBeUndefined();
+    expect(item.relatedTopicId).toBeUndefined();
+  });
+
+  it('should correctly type ActionItemFilters', () => {
+    const filters: ActionItemFilters = {
+      status: ['pending', 'in_progress'],
+      priority: ['high', 'medium', 'low'],
+    };
+
+    expect(filters.status).toBeDefined();
+    expect(filters.priority).toBeDefined();
+  });
+
+  it('should correctly type SortOrder and ActionItemSortField', () => {
+    const sortOrder: SortOrder = 'asc';
+    const sortField: ActionItemSortField = 'dueDate';
+
+    expect(sortOrder).toBe('asc');
+    expect(sortField).toBe('dueDate');
+  });
+});


### PR DESCRIPTION
## Summary
- アクションアイテム管理機能を実装（Phase2-1）
- 型定義: ManagedActionItem、フィルター、ソート、ページネーション型
- UIコンポーネント: Card、List、Stats、Filters、Search、Sort、Toolbar
- ActionItemService: CRUD操作（インメモリストレージ）
- API Routes: GET/POST/PATCH/DELETE、batch、stats
- 一覧ページ（/action-items）: フィルター・ソート・検索・URLパラメータ同期
- 議事録生成時にアクションアイテム自動保存
- MinutesViewerからステータス更新（楽観的更新）

## Test plan
- [ ] 型定義テスト（tests/types/action-item.test.ts）
- [ ] ActionItemServiceテスト（src/services/__tests__/action-item.service.test.ts）
- [ ] アクションアイテム一覧ページ表示確認
- [ ] フィルター・ソート・検索動作確認
- [ ] ステータス更新動作確認（MinutesViewer）
- [ ] 議事録生成時の自動保存確認

## Quality
- ReviewAgent: 92/100 PASS
- TypeScript/ESLint: 0 errors
- Tests: 136 cases added

Closes #8

---

Generated with [Claude Code](https://claude.ai/code)