### PR TITLE
fix: use MEETING_GET endpoint for fetching meeting details

### DIFF
--- a/src/lib/lark/__tests__/meeting.test.ts
+++ b/src/lib/lark/__tests__/meeting.test.ts
@@ -395,15 +395,14 @@ describe('MeetingService', () => {
   });
 
   describe('getMeetingById', () => {
-    it('should fetch from meeting_list and return matching meeting', async () => {
+    it('should fetch from MEETING_GET endpoint and return meeting', async () => {
       const mockResponse = {
         ok: true,
         json: vi.fn().mockResolvedValue({
           code: 0,
           msg: 'success',
           data: {
-            has_more: false,
-            meeting_list: [createMockLarkMeeting()],
+            meeting: createMockLarkMeeting(),
           },
         }),
       };
@@ -413,6 +412,27 @@ describe('MeetingService', () => {
 
       expect(meeting.id).toBe('meeting_001');
       expect(meeting.title).toBe('Weekly Team Standup');
+    });
+
+    it('should use MEETING_GET endpoint with meeting ID in path', async () => {
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 0,
+          msg: 'success',
+          data: {
+            meeting: createMockLarkMeeting(),
+          },
+        }),
+      };
+      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+      await service.getMeetingById(accessToken, 'meeting_001');
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/meetings/meeting_001'),
+        expect.any(Object)
+      );
     });
 
     it('should throw MeetingNotFoundError when data is undefined', async () => {
@@ -430,16 +450,12 @@ describe('MeetingService', () => {
       );
     });
 
-    it('should throw MeetingNotFoundError when meeting not in list', async () => {
+    it('should throw MeetingNotFoundError for not-found error codes', async () => {
       const mockResponse = {
         ok: true,
         json: vi.fn().mockResolvedValue({
-          code: 0,
-          msg: 'success',
-          data: {
-            has_more: false,
-            meeting_list: [createMockLarkMeeting()],
-          },
+          code: 99991663,
+          msg: 'Meeting not found',
         }),
       };
       vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
@@ -449,8 +465,18 @@ describe('MeetingService', () => {
       );
     });
 
-    it('should use meeting_list endpoint with meeting_no param', async () => {
-      const mockResponse = {
+    it('should fall back to meeting_list when MEETING_GET fails with other errors', async () => {
+      // First call (MEETING_GET) fails with a non-not-found error
+      const meetingGetResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 99991400,
+          msg: 'Permission denied',
+        }),
+      };
+
+      // Second call (meeting_list fallback) succeeds
+      const meetingListResponse = {
         ok: true,
         json: vi.fn().mockResolvedValue({
           code: 0,
@@ -461,32 +487,71 @@ describe('MeetingService', () => {
           },
         }),
       };
-      vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
 
-      await service.getMeetingById(accessToken, 'meeting_001');
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(meetingGetResponse as unknown as Response)
+        .mockResolvedValueOnce(meetingListResponse as unknown as Response);
 
-      expect(fetch).toHaveBeenCalledWith(
+      const meeting = await service.getMeetingById(accessToken, 'meeting_001');
+
+      expect(meeting.id).toBe('meeting_001');
+      // First call should be MEETING_GET, second should be meeting_list
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(fetch).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('/meetings/meeting_001'),
+        expect.any(Object)
+      );
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
         expect.stringContaining('/meeting_list'),
         expect.any(Object)
       );
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('meeting_no=meeting_001'),
-        expect.any(Object)
-      );
     });
-  });
 
-  describe('getParticipants', () => {
-    it('should fetch and transform participants', async () => {
-      // Mock for getMeetingById (uses meeting_list to get host info)
-      const meetingResponse = {
+    it('should throw MeetingNotFoundError when fallback also fails to find meeting', async () => {
+      // First call (MEETING_GET) fails
+      const meetingGetResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 99991400,
+          msg: 'Permission denied',
+        }),
+      };
+
+      // Second call (meeting_list fallback) returns empty list
+      const meetingListResponse = {
         ok: true,
         json: vi.fn().mockResolvedValue({
           code: 0,
           msg: 'success',
           data: {
             has_more: false,
-            meeting_list: [createMockLarkMeeting()],
+            meeting_list: [],
+          },
+        }),
+      };
+
+      vi.mocked(fetch)
+        .mockResolvedValueOnce(meetingGetResponse as unknown as Response)
+        .mockResolvedValueOnce(meetingListResponse as unknown as Response);
+
+      await expect(service.getMeetingById(accessToken, 'nonexistent_id')).rejects.toThrow(
+        MeetingNotFoundError
+      );
+    });
+  });
+
+  describe('getParticipants', () => {
+    it('should fetch and transform participants', async () => {
+      // Mock for getMeetingById (uses MEETING_GET to get host info)
+      const meetingResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          code: 0,
+          msg: 'success',
+          data: {
+            meeting: createMockLarkMeeting(),
           },
         }),
       };

--- a/src/lib/lark/meeting.ts
+++ b/src/lib/lark/meeting.ts
@@ -7,11 +7,13 @@ import type { LarkClient } from './client';
 import { LarkClientError } from './client';
 import {
   type LarkMeeting,
+  type LarkMeetingDetailData,
   type LarkMeetingListData,
   type LarkMeetingParticipant,
   type LarkMeetingRecording,
   type LarkParticipantListData,
   type LarkRecordingListData,
+  larkMeetingDetailResponseSchema,
   larkMeetingListResponseSchema,
   larkParticipantListResponseSchema,
   larkRecordingListResponseSchema,
@@ -349,9 +351,56 @@ export class MeetingService {
    * @throws {MeetingApiError} When the API request fails
    */
   async getMeetingById(accessToken: string, meetingId: string): Promise<Meeting> {
+    // Try the direct MEETING_GET endpoint first (works with User Access Token)
     try {
-      // The meeting detail endpoint (/meetings/:id) is not available for app access tokens.
-      // Fetch from meeting_list and find by ID instead.
+      const endpoint = LarkVCApiEndpoints.MEETING_GET.replace(
+        ':meeting_id',
+        meetingId
+      );
+
+      const response = await this.client.authenticatedRequest<LarkMeetingDetailData>(
+        endpoint,
+        accessToken
+      );
+
+      const validated = larkMeetingDetailResponseSchema.parse(response);
+
+      if (validated.data === undefined) {
+        throw new MeetingNotFoundError(meetingId);
+      }
+
+      return transformLarkMeeting(validated.data.meeting);
+    } catch (error) {
+      // If the direct endpoint fails (e.g. permission denied), fall back to meeting_list
+      if (error instanceof LarkClientError) {
+        if (error.code === 99991663 || error.code === 99991664) {
+          throw new MeetingNotFoundError(meetingId, error.message);
+        }
+
+        console.warn(
+          `[MeetingService] MEETING_GET failed (code: ${error.code}), falling back to meeting_list`,
+          error.message
+        );
+        return this.getMeetingByIdFromList(accessToken, meetingId);
+      }
+
+      if (error instanceof MeetingNotFoundError) {
+        throw error;
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * Fallback: Get meeting by searching the meeting_list endpoint
+   * Used when the direct MEETING_GET endpoint is not available
+   */
+  private async getMeetingByIdFromList(
+    accessToken: string,
+    meetingId: string
+  ): Promise<Meeting> {
+    try {
       const now = new Date();
       const ninetyDaysAgo = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
 
@@ -359,7 +408,6 @@ export class MeetingService {
         start_time: Math.floor(ninetyDaysAgo.getTime() / 1000).toString(),
         end_time: Math.floor(now.getTime() / 1000).toString(),
         page_size: '100',
-        meeting_no: meetingId,
       };
 
       const response = await this.client.authenticatedRequest<LarkMeetingListData>(
@@ -388,10 +436,7 @@ export class MeetingService {
         throw error;
       }
       if (error instanceof LarkClientError) {
-        if (error.code === 99991663 || error.code === 99991664) {
-          throw new MeetingNotFoundError(meetingId, error.message);
-        }
-        throw MeetingApiError.fromLarkClientError(error, 'getMeetingById');
+        throw MeetingApiError.fromLarkClientError(error, 'getMeetingByIdFromList');
       }
       throw error;
     }

--- a/src/lib/lark/types.ts
+++ b/src/lib/lark/types.ts
@@ -273,6 +273,13 @@ export const larkMeetingDetailDataSchema = z.object({
 export type LarkMeetingDetailData = z.infer<typeof larkMeetingDetailDataSchema>;
 
 /**
+ * Meeting detail response
+ */
+export const larkMeetingDetailResponseSchema = larkApiResponseSchema(larkMeetingDetailDataSchema);
+
+export type LarkMeetingDetailResponse = z.infer<typeof larkMeetingDetailResponseSchema>;
+
+/**
  * Participant user type
  */
 export const larkParticipantUserTypeSchema = z.enum([


### PR DESCRIPTION
## Summary
- `getMeetingById` was using the `meeting_list` endpoint with an invalid `meeting_no` filter param, which prevented retrieving individual meeting details
- Now uses the direct `MEETING_GET` endpoint (`/vc/v1/meetings/:meeting_id`) as the primary method
- Falls back to `meeting_list` search (without the broken `meeting_no` param) when the direct endpoint is unavailable (e.g. permission issues)
- Added `larkMeetingDetailResponseSchema` and `LarkMeetingDetailData` types for the detail endpoint response

## Changes
- `src/lib/lark/meeting.ts` - Rewrote `getMeetingById` with direct endpoint + fallback
- `src/lib/lark/types.ts` - Added meeting detail response schema
- `src/lib/lark/__tests__/meeting.test.ts` - Updated tests for new behavior (37 tests pass)

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 2032 tests pass (65 test files)
- [x] `getMeetingById` tests cover: direct endpoint success, not-found errors, fallback behavior, fallback not-found

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)